### PR TITLE
ユーザーネーム変更機能の実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,7 +2,8 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  # updateメソッド時に与えるストロングパラメータの設定用。
+  before_action :configure_account_update_params, only: [ :update ]
 
   # GET /resource/sign_up
   # def new
@@ -38,17 +39,29 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
   # end
 
+  # password無しで詳細を変更するための記載。
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+  end
+
+  # updateメソッド実行時の遷移先指定用オーバーライド
+  # 更新が終わった際に、再度プロフィール設定画面が表示されるようにしたい
+  def after_update_path_for(resource)
+    edit_user_registration_path(resource) # ここにリダイレクト先のパスを指定
+  end
+
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,18 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  # パスワード無しで更新するためのメソッド。
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
+  end
 end

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -16,7 +16,7 @@
           </svg>
         </div>
 
-        <div> <%# 同意して登録ボタン %>
+        <div> <%# アイコン変更ボタン %>
           <button
             type="submit"
             name="commit"
@@ -31,7 +31,6 @@
       </div>
 
       <div class="p-6 flex flex-col"> <%# フォーム本体枠 %>
-        <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
           <div class="flex flex-col"> <%# 「ログイン」以下のフォーム部分 %>
             <div class="mx-auto max-w-xs"> <%# メールで登録 %>
               <div class=""> <%# ユーザーネーム %>
@@ -44,29 +43,34 @@
                       <button x-on:click="modalIsOpen = true" type="button" class="flex items-center">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="cursor-pointer size-6 opacity-70 hover:opacity-100 transition-opacity" fill="currentColor"><path d="M5 18.89H6.41421L15.7279 9.57627L14.3137 8.16206L5 17.4758V18.89ZM21 20.89H3V16.6473L16.435 3.21231C16.8256 2.82179 17.4587 2.82179 17.8492 3.21231L20.6777 6.04074C21.0682 6.43126 21.0682 7.06443 20.6777 7.45495L9.24264 18.89H21V20.89ZM15.7279 6.74785L17.1421 8.16206L18.5563 6.74785L17.1421 5.33363L15.7279 6.74785Z"></path></svg> <%# https://remixicon.com/icon/edit-2-line %>
                       </button>
-                      <div x-cloak x-show="modalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="modalIsOpen" x-on:keydown.esc.window="modalIsOpen = false" x-on:click.self="modalIsOpen = false" class="fixed inset-0 z-30 flex items-end justify-center bg-black/20 p-4 pb-8 backdrop-blur-md sm:items-center lg:p-8" role="dialog" aria-modal="true" aria-labelledby="defaultModalTitle">
-                          <!-- Modal Dialog -->
-                          <div x-show="modalIsOpen" x-transition:enter="transition ease-out duration-200 delay-100 motion-reduce:transition-opacity" x-transition:enter-start="opacity-0 scale-50" x-transition:enter-end="opacity-100 scale-100" class="flex max-w-lg flex-col gap-4 overflow-hidden rounded-sm border border-neutral-300 bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300">
-                              <!-- Dialog Header -->
-                              <div class="flex items-center justify-between border-b border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20">
-                                  <h3 id="defaultModalTitle" class="font-semibold tracking-wide text-neutral-900 dark:text-white">ユーザーネーム変更</h3>
-                                  <button x-on:click="modalIsOpen = false" aria-label="close modal">
-                                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" fill="none" stroke-width="1.4" class="w-5 h-5">
-                                          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                                      </svg>
-                                  </button>
-                              </div>
-                              <!-- Dialog Body -->
-                              <div class="px-4 py-8">
-                                  <p>ユーザーネームを変更する箇所です。</p>
-                              </div>
-                              <!-- Dialog Footer -->
-                              <div class="flex flex-col-reverse justify-between gap-2 border-t border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20 sm:flex-row sm:items-center md:justify-end">
-                                  <button x-on:click="modalIsOpen = false" type="button" class="whitespace-nowrap rounded-sm px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-600 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:text-neutral-300 dark:focus-visible:outline-white">キャンセル</button>
-                                  <button x-on:click="modalIsOpen = false" type="button" class="whitespace-nowrap rounded-sm bg-black border border-black dark:border-white px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-100 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:bg-white dark:text-black dark:focus-visible:outline-white">変更する</button>
-                              </div>
-                          </div>
-                      </div>
+                      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+                        <div x-cloak x-show="modalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="modalIsOpen" x-on:keydown.esc.window="modalIsOpen = false" x-on:click.self="modalIsOpen = false" class="fixed inset-0 z-30 flex justify-center bg-black/20 p-4 pb-8 backdrop-blur-md items-center lg:p-8" role="dialog" aria-modal="true" aria-labelledby="defaultModalTitle">
+                            <!-- Modal Dialog -->
+                            <div x-show="modalIsOpen" x-transition:enter="transition ease-out duration-200 delay-100 motion-reduce:transition-opacity" x-transition:enter-start="opacity-0 scale-50" x-transition:enter-end="opacity-100 scale-100" class="flex max-w-lg flex-col gap-4 overflow-hidden rounded-sm border border-neutral-300 bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300">
+                                <!-- Dialog Header -->
+                                <div class="flex items-center justify-between border-b border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20">
+                                    <h3 id="defaultModalTitle" class="font-semibold tracking-wide text-neutral-900 dark:text-white">ユーザーネーム変更</h3>
+                                    <button x-on:click="modalIsOpen = false" type="button" aria-label="close modal">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" fill="none" stroke-width="1.4" class="w-5 h-5">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                                <!-- Dialog Body -->
+                                <div class="m-5 px-4 py-8 w-96">
+                                  <div> <%# ネーム入力欄%>
+                                    <%= f.label :name, "ユーザーネーム", class:"font-bold mb-1" %>
+                                    <%= f.text_field :name, value: current_user.name.presence || '', placeholder: "アプリ内で使用するネームを登録してください", class: "w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" %>
+                                  </div>
+                                </div>
+                                <!-- Dialog Footer -->
+                                <div class="flex flex-col-reverse gap-2 border-t border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20 sm:flex-row sm:items-center justify-end">
+                                    <button x-on:click="modalIsOpen = false" type="button" class="whitespace-nowrap rounded-sm px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-600 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:text-neutral-300 dark:focus-visible:outline-white underline">キャンセル</button>
+                                    <%= f.submit "変更する", class: "whitespace-nowrap rounded-sm bg-black border border-black dark:border-white px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-100 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:bg-white dark:text-black dark:focus-visible:outline-white" %>
+                                </div>
+                            </div>
+                        </div> <%# ↑ユーザーネーム変更モーダル中身 %>
+                      <% end %>
                   </div>
                 </div>
               </div>
@@ -137,7 +141,6 @@
               </div>
             </div>
           </div>
-        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 実施内容
- ユーザー情報変更機能のうち、ユーザーネームの変更機能を実装しました。
- deviceのデフォルト設定である「パスワードの入力」無しでもユーザー情報を変更できるよう、registrations_controller.rbに記載を施しました。

編集・作成した主なファイルは以下の通りです。
 -  `app/views/users/registrations/edit.html.erb`
    - ユーザーネーム変更モーダルにフォームの設置
    - form_forヘルパーの設置。
- `app/controllers/users/registrations_controller.rb`
    - usersのupdateメソッド実行時のパラメータ記載。
    - updateメソッド実行時の遷移先を`after_update_path_for`メソッドをオーバーライドすることで指定。
- `app/models/user.rb`
    - パスワード確認無しで更新を行うためのメソッドを記載。

## 備考
- 新規登録段階ではユーザーネームの登録は行わず、ユーザーが必要に応じてログイン後に自身で設定する形をとる。そのためユーザー登録後に「ユーザーネームはプロフィール設定画面から設定・変更できます」という旨の表示がされるようtoastを実装する必要がある。
- プロフィール変更時のエラー表示を実装する。



## 実施タスク
close #39 