### PR TITLE
公開済みカラーパレットの雛形作成

### DIFF
--- a/app/views/shared/post_card/_draft_palette.html.erb
+++ b/app/views/shared/post_card/_draft_palette.html.erb
@@ -1,6 +1,6 @@
 <%# 下書きパレット用カードコンポーネント %>
 <div class="max-w-[720px]">
-  <div class="relative flex w-full max-w-[26rem] flex-col rounded-xl bg-white bg-clip-border text-gray-700 shadow-lg">
+  <div class="relative flex w-full max-w-[26rem] h-[29rem] flex-col rounded-xl bg-white bg-clip-border text-gray-700 shadow-lg">
     <div class="w-96 h-56 flex relative mx-4 mt-8 overflow-hidden text-white shadow-xl rounded-md bg-blue-gray-500 bg-clip-border shadow-blue-gray-500/40">
       <div class="w-[20%] h-full bg-red-500"></div>
       <div class="w-[30%] h-full bg-green-500"></div>

--- a/app/views/shared/post_card/_my_published_palette.html.erb
+++ b/app/views/shared/post_card/_my_published_palette.html.erb
@@ -1,0 +1,52 @@
+<%# 公開済みパレット用カードコンポーネント %>
+<div class="max-w-[720px]">
+  <div class="relative flex w-full max-w-[26rem] h-[29rem] flex-col rounded-xl bg-white bg-clip-border text-gray-700 shadow-lg">
+    <div class="w-96 h-56 flex relative mx-4 mt-8 overflow-hidden text-white shadow-xl rounded-md bg-blue-gray-500 bg-clip-border shadow-blue-gray-500/40">
+      <div class="w-[20%] h-full bg-red-500"></div>
+      <div class="w-[30%] h-full bg-green-500"></div>
+      <div class="w-[50%] h-full bg-blue-500"></div>
+    </div>
+    <div class="p-6">
+      <div class="flex items-center justify-between"> <%# タイトルといいね用 %>
+        <h5 class="block font-sans text-2xl antialiased font-medium leading-snug tracking-normal text-blue-gray-900">
+            Published Palette
+        </h5>
+        <div class="flex mr-3 items-end">
+          <button type="button" disabled>
+            <svg xmlns="http://www.w3.org/2000/svg" class="size-10" viewBox="0 0 24 24" fill="currentColor"><path d="M12.001 4.52853C14.35 2.42 17.98 2.49 20.2426 4.75736C22.5053 7.02472 22.583 10.637 20.4786 12.993L11.9999 21.485L3.52138 12.993C1.41705 10.637 1.49571 7.01901 3.75736 4.75736C6.02157 2.49315 9.64519 2.41687 12.001 4.52853ZM18.827 6.1701C17.3279 4.66794 14.9076 4.60701 13.337 6.01687L12.0019 7.21524L10.6661 6.01781C9.09098 4.60597 6.67506 4.66808 5.17157 6.17157C3.68183 7.66131 3.60704 10.0473 4.97993 11.6232L11.9999 18.6543L19.0201 11.6232C20.3935 10.0467 20.319 7.66525 18.827 6.1701Z"></path></svg>
+          </button>
+          <div class="select-none">123</div>
+        </div>
+      </div>
+      <div class="flex items-center gap-2"> <%# 作成者用 %>
+        <div class="flex items-center gap-1"> <%# 作成者 %>
+          <svg class="size-5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 256 256" xml:space="preserve">
+            <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(1.4065934065934016 1.4065934065934016) scale(2.81 2.81)">
+              <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
+            </g>
+          </svg>
+          <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
+            username1
+          </p>
+        </div>
+      </div>
+      <div class="flex items-center gap-2 mt-2"> <%# 状態タグと公開日時用 %>
+        <span class="inline-flex items-center gap-x-1 py-1 px-2 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-800/30 dark:text-blue-500"> <%# https://preline.co/docs/badge.html %>
+          <span class="size-1.5 inline-block rounded-full bg-blue-800 dark:bg-blue-500"></span>
+          公開済み
+        </span>
+        <div class="bg-gray-100 text-gray-800 text-xs font-medium flex gap-1 items-center rounded-sm dark:bg-gray-700 dark:text-gray-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="size-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20ZM13 12H17V14H11V7H13V12Z"></path></svg>
+          <p>3 days ago<p>
+        </div> <%# 作成日時用 %>
+      </div>
+    </div>
+    <div class="px-6">
+      <div class="flex items-center justify-end"><%# 詳細ページ矢印用 %>
+        <div class="">
+          <svg xmlns="http://www.w3.org/2000/svg" class="opacity-80 transition-all duration-500 ease-out hover:scale-125 hover:opacity-100 size-10 mr-4" viewBox="0 0 24 24" fill="currentColor"><path d="M16.1716 10.9999L10.8076 5.63589L12.2218 4.22168L20 11.9999L12.2218 19.778L10.8076 18.3638L16.1716 12.9999H4V10.9999H16.1716Z"></path></svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,4 +1,5 @@
 <div class="my-10 lg:mx-10 gap-10 flex flex-wrap justify-center">
   <%= render "shared/post_card/draft_palette" %>
+  <%= render "shared/post_card/my_published_palette" %>
 </div>
 


### PR DESCRIPTION
## 実施内容
公開済みのパレットの一覧表示用コンポーネントの雛形を作成しました。
[![Image from Gyazo](https://i.gyazo.com/9e983c5d49967085f8f3364d2a6c137d.jpg)](https://gyazo.com/9e983c5d49967085f8f3364d2a6c137d)

- ユーザーが自身で作成したパレットの「下書き」と、また他のユーザーが公開したパレットとの区別がつきやすいように、「公開済み」のタグを配置しました。
- 「セルフいいね」ができないよう、非活性の「いいね」ボタンを設置しました。
- 詳細ページに移動するための矢印ボタンを設置しました。

編集・作成した主なファイルは以下の通りです。
- `app/views/shared/post_card/_my_published_palette.html.erb`
    - 自作の公開済みパレット一覧表示用パーシャルviewファイル。

## 備考
- 一覧表示にも共有ボタンや画像保存ボタンを設置すべきか、もしくは詳細ページにのみこれらのオプションボタンをつけるべきか、今後開発で考慮する必要あり。

## 実施タスク
close #37 