### PR TITLE
パレット作成画面のプレビュー・公開設定コンポーネントの雛形作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,2 @@
+class PostsController < ApplicationController
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/views/layouts/_header_logged_in.erb
+++ b/app/views/layouts/_header_logged_in.erb
@@ -24,7 +24,7 @@
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M18.031 16.6168L22.3137 20.8995L20.8995 22.3137L16.6168 18.031C15.0769 19.263 13.124 20 11 20C6.032 20 2 15.968 2 11C2 6.032 6.032 2 11 2C15.968 2 20 6.032 20 11C20 13.124 19.263 15.0769 18.031 16.6168ZM16.0247 15.8748C17.2475 14.6146 18 12.8956 18 11C18 7.1325 14.8675 4 11 4C7.1325 4 4 7.1325 4 11C4 14.8675 7.1325 18 11 18C12.8956 18 14.6146 17.2475 15.8748 16.0247L16.0247 15.8748Z"></path></svg>
                     <span>検索</span>
                   <% end %> <%# 検索ボタン %>
-                  <%= link_to "#", class: "flex items-center gap-2 px-3 py-2 mx-2 mt-2 text-gray-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700" do%>
+                  <%= link_to new_post_path, class: "flex items-center gap-2 px-3 py-2 mx-2 mt-2 text-gray-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700" do%>
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M11 11V7H13V11H17V13H13V17H11V13H7V11H11ZM12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20Z"></path></svg>
                     <span>新規作成</span>
                   <% end %> <%# 新規作成ボタン %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,79 @@
+<!-- source:https://codepen.io/owaiswiz/pen/jOPvEPB -->
+<div class= "min-h-fit bg-gray-100 text-gray-900 flex items-center justify-center"> <%# フォーム画面の土台枠外span %>
+  <div class="mx-20 my-5 md:mx-0">
+    <div class="max-w-fit mb-6"> <%# 戻るボタン設置 %>
+    <%= render 'shared/back_button' %>
+    </div>
+    <div class="mb-1 text-xl font-bold">パレット作成 </div>
+    <div class="px-2 sm:p-5  bg-white shadow sm:rounded-lg flex flex-col lg:flex-row  items-center justify-center"> <%# フォームの大枠span・右半分と左半分で分けてるところ %>
+      <div class="flex flex-col p-6"> <%# 左側欄 %>
+        <div class="flex justify-between items-end">
+          <div class="text-xl font-bold">プレビュー</div> <%# プレビュー見出し %>
+          <div x-data="{modalIsOpen: false}" class="mr-3"> <%# パレットを削除する %>
+            <button x-on:click="modalIsOpen = true" type="button" class="flex items-center">
+              <p class="text-xs text-center text-orange-400 hover:text-orange-600 border-b border-orange-400">パレットを削除する</p>
+            </button>
+            <div x-cloak x-show="modalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="modalIsOpen" x-on:keydown.esc.window="modalIsOpen = false" x-on:click.self="modalIsOpen = false" class="fixed inset-0 z-30 flex items-end justify-center bg-black/20 p-4 pb-8 backdrop-blur-md sm:items-center lg:p-8" role="dialog" aria-modal="true" aria-labelledby="defaultModalTitle">
+                <!-- Modal Dialog -->
+                <div x-show="modalIsOpen" x-transition:enter="transition ease-out duration-200 delay-100 motion-reduce:transition-opacity" x-transition:enter-start="opacity-0 scale-50" x-transition:enter-end="opacity-100 scale-100" class="flex max-w-lg flex-col gap-4 overflow-hidden rounded-sm border border-neutral-300 bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300">
+                    <!-- Dialog Header -->
+                    <div class="flex items-center justify-between border-b border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20">
+                        <h3 id="defaultModalTitle" class="font-semibold tracking-wide text-neutral-900 dark:text-white">パレット削除</h3>
+                        <button x-on:click="modalIsOpen = false" aria-label="close modal">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" fill="none" stroke-width="1.4" class="w-5 h-5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <!-- Dialog Body -->
+                    <div class="px-4 py-8">
+                        <p>開発予定。準備中です。</p>
+                    </div>
+                    <!-- Dialog Footer -->
+                </div>
+            </div>
+          </div>
+        </div>
+        <div class="w-[24rem] h-56 md:w-[28rem] md:h-72 mt-3 flex justify-center items-center overflow-hidden text-white shadow-xl rounded-xl bg-blue-gray-500 bg-clip-border border-2">
+          <div class="w-80 h-48 md:w-96 md:h-56 flex overflow-hidden text-white shadow-xl rounded-md bg-blue-gray-500 bg-clip-border shadow-blue-gray-500/40">
+            <div class="w-[60%] h-full bg-[#fcf7b0]"></div>
+            <div class="w-[5%] h-full bg-[#e8380d]"></div>
+            <div class="w-[45%] h-full bg-[#004c83]"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-6 flex flex-col"> <%# フォーム本体枠 %>
+        <div class="mx-auto max-w-xs">
+          <div class="mt-3"> <%# タイトル %>
+            <p class="font-bold">タイトル</p>
+            <div class="flex gap-1 items-center justify-center">
+              <input placeholder="non-title" class="w-80 px-4 py-2 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white">
+              </input>
+            </div>
+          </div>
+
+          <div class="mt-3"> <%# 概要欄(任意) %>
+            <p class="font-bold">概要欄(任意)</p>
+            <div class="flex gap-1 items-center justify-center">
+              <textarea disabled rows="3" placeholder="※本リリースにて開発予定です。" class="w-80 px-4 py-2 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white"></textarea>
+            </div>
+          </div>
+
+          <div class="mt-3"> <%# タグ(任意) %>
+            <p class="font-bold">タグ</p>
+            <div class="flex gap-1 items-center justify-center">
+              <input disabled placeholder="※本リリースにて開発予定です。" class="w-80 px-4 py-2 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white"/>
+            </div>
+          </div>
+
+          <div class="mt-5 flex gap-2 justify-end">
+            <button type="button" class="py-2.5 px-5 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700">下書き保存</button> <%# https://flowbite.com/docs/components/buttons/ %>
+            <button type="button" class="focus:outline-none text-white bg-orange-400 hover:bg-orange-500 font-medium rounded-lg text-sm px-5 py-2.5">公開する</button>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   root to: "top#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
+  # postsコントローラーのルーティング
+  resources :posts
+
   # 静的ページ用ルーティング
   resource :static, only: [] do
     collection do

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 実施内容
- パレット新規作成画面におけるプレビュー確認と、公開設定コンポーネントのviewを作成しました。
- 投稿関連のコントローラー、およびルーティングの記載を行いました。

[![Image from Gyazo](https://i.gyazo.com/c9d505a52b048d41fa4aa3cbd9ef0383.jpg)](https://gyazo.com/c9d505a52b048d41fa4aa3cbd9ef0383)

編集・作成した主なファイルは以下の通りです。
- `config/routes.rb`
    - 投稿関連のルーティング設定。
- `app/views/layouts/_header_logged_in.erb`
    - ヘッダー新規作成ボタン押下時の遷移設定。
- `app/views/posts/new.html.erb`
    - 新規投稿用viewファイル。

## 備考
- 下書き保存ボタンと公開ボタンの配置方法について考える必要あり。(横並びorトグル選択型orその他)。ユーザーにとってご選択が起こらないようUIをブラッシュアップしていく。
- largeサイズの画面でも最初からプレビュー画面と入力欄を縦に並べて、色選択画面と今回のコンポーネントを左右に並べるような配置も試してみると良いかも。現段階で予定している配置方法だと、PCでの操作であっても新規登録画面でかなりのスクロールを強いる状態になってしまう。

## 実施タスク
close #40 