### PR TITLE
レンジスライダーを使用した配色の比率設定用コンポーネント作成

### DIFF
--- a/app/assets/stylesheets/_range_slider.scss
+++ b/app/assets/stylesheets/_range_slider.scss
@@ -1,0 +1,46 @@
+.noUi-horizontal {
+  height: 1rem;
+  background-color: #b19962; //スライダーそのものの背景色部分。
+  border: none;
+
+  .noUi-handle {
+    height: 3.5rem;
+    width: 0.5rem;
+    border:1px solid #ccc;
+    background: #fff;
+    top: -1rem;
+    right: -4px; //メモリ部分と微妙にズレてる部分を合わせるため。
+    &:before,
+    &:after { content:none; }
+    cursor: pointer;
+    transition: all 0.3s ease-out;
+    &:hover,
+    &:active {
+      transform: scale(1.1);
+      background: #f3f4f6;
+    &:active {
+      border: 1px solid #fb923c; // active時のみ枠線色つける。
+    }
+    }
+  }
+}
+
+// .noUi-touch-area {
+//   padding: 0 10px; // つまみの掴める範囲をもう少し大きくしたいためのコード
+// }
+
+
+.noUi-tooltip {
+  display: none !important;
+  font-size: 1rem;
+
+  .noUi-active & { //親要素にアクティブがついた時だけ.noUi-tooltipをdisplay: blockに指定。
+    display: block !important;
+  }
+}
+
+.noUi-handle-upper,
+.noUi-handle-lower,
+.noUi-draggable {
+  pointer-events: none; //両端のハンドルを動かせないようにするために根本的にユーザー選択を無効化する。
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+@import 'range_slider';
+
 .main-container {
   display: grid;
   grid-template-rows: auto 1fr auto;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./range_slider"

--- a/app/javascript/range_slider.js
+++ b/app/javascript/range_slider.js
@@ -1,0 +1,60 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const slider = document.getElementById('ratio-slider');
+  // 色情報の配列を格納する変数を定義。
+  const classes = ['#150c15', '#9a1117', '#917c50', '#bbe3f5', '#da6a38'];
+  // 色の数管理用の変数を定義。(JSでの要素数取得メソッドはlengthのみ)
+  const colorCount = classes.length;
+
+  // つまみの数を使用する色の数で動的管理するための変数を定義。(3色使用の場合は4つ摘みが必要になる。)
+  const handleCount = colorCount + 1;
+  // ツールチップを実装するための定義。下のnoUiSlider.createのtooltips: toolTipsで参照する。
+  const toolTips = [false]; //1つ目のつまみはツールチップを表示する必要がないからfalseにしておく。
+  for (let i=1; i < handleCount; i++) {
+    toolTips.push({ to: function(value) { return value + '%';}});
+  }
+
+  // デフォルトのつまみ設置場所を定義しておく。{色の数: noUiのスタート位置}の形。
+  const defaultRanges = {
+    2: [0, 50, 100],
+    3: [0, 35, 70, 100],
+    4: [0, 25, 50, 75, 100],
+    5: [0, 20, 40, 60, 80, 100]
+  };
+
+  // noUiのconnectイベント用の配列をハッシュ形式で格納しておく。
+  const defaultConnects = {
+    2: [false, true, true, false],
+    3: [false, true, true, true, false],
+    4: [false, true, true, true, true, false],
+    5: [false, true, true, true, true, true, false]
+  };
+
+
+  noUiSlider.create(slider, {
+    start: defaultRanges[colorCount], // ハッシュのインデックスは色の数で指定することに注意(handleCountではない。)
+    behaviour: 'drag-all', //スライドをまとめてドラックできるオプション。両端をcssで動かせないようにすることで、完全に固定するための逆説的な使い方試してみた…
+    connect: defaultConnects[colorCount], // 上で定義したdefaultConnectsでconnect状態を数に対応させる。
+    range: {
+      'min': 0,
+      'max': 100
+    },
+    margin: 5, // ハンドル同士の最小距離。5にしたら、少なくとも5%の幅は持てる？
+    step: 5,
+
+    tooltips: toolTips, //上で定義したツールチップ用配列を使用。
+
+    pips: {  // 特定の間隔で値のマーカーを追加
+      mode: 'positions',
+      values: [0,25,50,75,100],
+      density: 5 // 小さいメモリの間隔5%ごとに
+    }
+  })
+
+
+  // つまみ間に色をつけたい。
+  var connect = slider.querySelectorAll('.noUi-connect');
+
+  for (var i = 0; i < connect.length; i++) {
+      connect[i].style.background = classes[i]; // backgroundのスタイルを直接指定する。
+  }
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/15.8.1/nouislider.css" integrity="sha512-MKxcSu/LDtbIYHBNAWUQwfB3iVoG9xeMCm32QV5hZ/9lFaQZJVaXfz9aFa0IZExWzCpm7OWvp9zq9gVip/nLMg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
@@ -27,5 +28,7 @@
       <%= yield %>
       <%= render 'layouts/footer' %>
     </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/15.8.1/nouislider.min.js" integrity="sha512-g/feAizmeiVKSwvfW0Xk3ZHZqv5Zs8PEXEBKzL15pM0SevEvoX8eJ4yFWbqakvRj7vtw1Q97bLzEpG2IVWX0Mg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/wnumb/1.2.0/wNumb.min.js" integrity="sha512-igVQ7hyQVijOUlfg3OmcTZLwYJIBXU63xL9RC12xBHNpmGJAktDnzl9Iw0J4yrSaQtDxTTVlwhY730vphoVqJQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   </body>
 </html>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -77,6 +77,7 @@
     </div>
 
     <%= render "shared/edit_palette/palette_base" %>
+    <%= render "shared/edit_palette/color_ratio" %>
   </div>
 </div>
 

--- a/app/views/shared/edit_palette/_color_ratio.html.erb
+++ b/app/views/shared/edit_palette/_color_ratio.html.erb
@@ -1,0 +1,9 @@
+<div class="my-10 flex flex-col">
+  <div class="flex items-end gap-1"> <%# 「配色の比率設定」見出し用 %>
+    <svg xmlns="http://www.w3.org/2000/svg" class="ml-2 size-8" viewBox="0 0 24 24" fill="currentColor"><path d="M11 2V22H13V2H11ZM2 6C2 4.89543 2.89543 4 4 4H7C8.10457 4 9 4.89543 9 6V18C9 19.1046 8.10457 20 7 20H4C2.89543 20 2 19.1046 2 18V6ZM20 6V18H17V6H20ZM17 4C15.8954 4 15 4.89543 15 6V18C15 19.1046 15.8954 20 17 20H20C21.1046 20 22 19.1046 22 18V6C22 4.89543 21.1046 4 20 4H17Z"></path></svg>
+    <div class="text-xl font-bold">配色の比率設定</div>
+  </div>
+  <div class="w-[28rem] h-40 px-1 py-2 mt-1 bg-white flex justify-center items-center overflow-hidden shadow-xl rounded-xl bg-blue-gray-500 border-2">
+    <div id="ratio-slider" class="w-[24rem]"></div>
+  </div>
+</div>


### PR DESCRIPTION
## 実施内容
- パレット作成画面における、それぞれの色の配色比率を設定するためのコンポーネントを作成しました。レンジスライダーの機能を応用して実装しております。
- 使用する色の数によってレンジスライダーのつまみが動的に変化します。ユーザーはこのつまみのうち、両端以外の部分をドラックして操作することで、各配色の比率を視覚的に効率よく調節することができます。
- 本アプリで作成するカラーパレットの前提「5%単位で配色比率を設定できる」機能を実現するために、レンジスライダーのつまみは5%単位で調整できるよう実装しました。


[![Image from Gyazo](https://i.gyazo.com/9bdbebea137f7405c6aba7166c4688dc.jpg)](https://gyazo.com/9bdbebea137f7405c6aba7166c4688dc)

編集・作成した主なファイルは以下の通りです。
- `app/views/shared/edit_palette/_color_ratio.html.erb`
    - パレットのカラー比率設定用パーシャルの作成。
- `app/views/posts/new.html.erb`
    - `_color_ratio.html.erb`の呼び出しを記載。
- `app/javascript/range_slider.js`
    - noUiSliderライブラリを使用したレンジスライダー実装用jsファイル。
- `app/javascript/application.js`
    - `range_slider.js`の読み込みを記載。
- `app/assets/stylesheets/_range_slider.scss`
    - noUiSliderで作成したレンジスライダーのスタイル変更用scssファイル。

## 備考
- レンジスライドから実際の配色比率を取得するための実装が必要。(現段階では0%地点からの比率しか取得できないため、1色目は問題ないが、2色目以降の比率が効率よく取得できない状態。)
- ベース設定画面の比率表示欄と、今回実装した配色比率画面で設定した比率情報を紐づける必要がある(どちらかの値を操作したら、もう片方の該当箇所も動的に変更されるようにする必要がある)

## 実施タスク
close #42 