### PR TITLE
カラーパレット削除機能の実装 #21

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,8 @@
 class PostsController < ApplicationController
+  def index
+    @posts = Post.where(status: "published")
+  end
+
   def new
     @color_candidate = [
       [ "#303967", "#e60012", "#ffe200" ],
@@ -24,9 +28,13 @@ class PostsController < ApplicationController
     # input_colors = params[:post][:color].split(',') # colorの入力値を配列の形でinput_colorsに格納する。
     @post.create_colors(input_colors) # create_colorsをpost.rbにメソッド記載。colorテーブルの作成と中間テーブルへの登録を行うためのメソッド。
     if @post.save
-      redirect_to post_path(@post) # 作成が成功したら詳細ページへ移動する。
+      if @post.status == "draft"
+        redirect_to post_path(@post), notice: "下書きを保存しました。" # 作成が成功したら詳細ページへ移動する。
+      else
+        redirect_to post_path(@post), notice: "パレットを公開しました。"
+      end
     else
-      render :new
+    render :new
     end
   end
 
@@ -39,10 +47,17 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
-    @colors = @post.colors
   end
 
   def destroy
+    @post = Post.find(params[:id])
+    if @post.user_id == current_user.id
+      if @post.destroy
+        redirect_to root_path, notice: "削除が完了しました"
+      else
+        redirect_to root_path, alert: "削除に失敗しました"
+      end
+    end
   end
 
   private

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,14 @@
+<div class="my-16">
+  <div class="text-3xl mb-10 ml-10 lg:ml-24">投稿一覧</div>
+  <div class="flex flex-wrap justify-center gap-5 mx-5">
+    <% @posts.each do |post|  %> <%# @postsはすでにpublishedのものだけ入ってる状態 %>
+      <%# ログインしてる状態ならそれが自分の投稿かを確認、trueなら自投稿用のviewでパレット表示 %>
+      <% if user_signed_in? && post.user_id == current_user.id %>
+        <%= render "shared/post_card/my_published_palette", post: post %>
+      <%# ログインしてない状態orログインしてるけど自分の投稿じゃなかった場合は、問答無用で他の人の投稿になるため一般表示用viewでパレット表示 %>
+      <% else %>
+        <%= render "shared/post_card/published_palette", post: post %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -14,30 +14,13 @@
         <div class="flex flex-col p-6"> <%# 左側欄 %>
           <div class="flex justify-between items-end">
             <div class="text-xl font-bold">プレビュー</div> <%# プレビュー見出し %>
-            <div x-data="{modalIsOpen: false}" class="mr-3"> <%# パレットを削除する %>
-              <button x-on:click="modalIsOpen = true" type="button" class="flex items-center">
-                <p class="text-xs text-center text-orange-400 hover:text-orange-600 border-b border-orange-400">パレットを削除する</p>
-              </button>
-              <div x-cloak x-show="modalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="modalIsOpen" x-on:keydown.esc.window="modalIsOpen = false" x-on:click.self="modalIsOpen = false" class="fixed inset-0 z-30 flex items-end justify-center bg-black/20 p-4 pb-8 backdrop-blur-md sm:items-center lg:p-8" role="dialog" aria-modal="true" aria-labelledby="defaultModalTitle">
-                  <!-- Modal Dialog -->
-                  <div x-show="modalIsOpen" x-transition:enter="transition ease-out duration-200 delay-100 motion-reduce:transition-opacity" x-transition:enter-start="opacity-0 scale-50" x-transition:enter-end="opacity-100 scale-100" class="flex max-w-lg flex-col gap-4 overflow-hidden rounded-sm border border-neutral-300 bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300">
-                      <!-- Dialog Header -->
-                      <div class="flex items-center justify-between border-b border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20">
-                          <h3 id="defaultModalTitle" class="font-semibold tracking-wide text-neutral-900 dark:text-white">パレット削除</h3>
-                          <button x-on:click="modalIsOpen = false" aria-label="close modal">
-                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" fill="none" stroke-width="1.4" class="w-5 h-5">
-                                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                              </svg>
-                          </button>
-                      </div>
-                      <!-- Dialog Body -->
-                      <div class="px-4 py-8">
-                          <p>開発予定。準備中です。</p>
-                      </div>
-                      <!-- Dialog Footer -->
-                  </div>
+            <% if @post.id.present? %> <%# 既存パレット編集時は削除ボタンを表示して、新規作成時は表示しないための記載 %>
+              <div class="mr-3"> <%# パレットを削除する %>
+                <%= link_to post_path(@post), data: {turbo_method: :delete, turbo_confirm: "下書きを削除します。よろしいですか?"}, class:"text-xs text-center text-orange-400 hover:text-orange-600 border-b border-orange-400" do %>
+                  <p>パレットを削除する</p>
+                <% end %>
               </div>
-            </div>
+            <% end %>
           </div>
           <div class="w-[24rem] h-56 lg:w-[28rem] lg:h-72 mt-3 flex justify-center items-center overflow-hidden text-white shadow-xl rounded-xl bg-blue-gray-500 bg-clip-border border-2">
             <div class="w-80 h-48 lg:w-96 lg:h-56 flex overflow-hidden text-white shadow-xl rounded-md bg-blue-gray-500 bg-clip-border shadow-blue-gray-500/40">
@@ -82,12 +65,14 @@
               </div>
             </div>
 
-            <div class="mt-3"> <%# タグ(任意) %>
+            <div class="my-3"> <%# タグ(任意) %>
               <p class="font-bold">タグ</p>
               <div class="flex gap-1 items-center justify-center">
                 <input disabled placeholder="※本リリースにて開発予定です。" class="w-80 px-4 py-2 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white"/>
               </div>
             </div>
+
+            <%= link_to "※保存せず終了する", root_path, data: { turbo_method: :get, turbo_confirm: "直近に保存した内容からの変更を反映せずに終了し、トップページに戻ります。よろしいですか?"}, class:"text-xs text-center text-blue-500 hover:text-blue-600 active:text-blue-500 underline" %>
 
             <div class="mt-5 flex gap-2 justify-end">
               <%= f.submit "下書き保存", id:"draft_button",  class:"py-2.5 px-5 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" %> <%# https://flowbite.com/docs/components/buttons/ %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,10 @@
+<% post = @post %>
 <div class="my-10 lg:mx-20 gap-5 flex flex-wrap justify-center">
-<% if @post.status == "draft" %>
-  <%= render "shared/post_card/draft_palette" %>
-<% elsif @post.status == "published" %>
-  <%= render "shared/post_card/my_published_palette" %>
-<% end %>
+  <% if post.user_id == current_user.id && post.status == "draft"  %>
+    <%= render "shared/post_card/draft_palette", post: post %>
+  <% elsif post.user_id == current_user.id && post.status == "published" %>
+    <%= render "shared/post_card/my_published_palette", post: post %>
+  <% elsif post.user_id != current_user.id && post.status == "published" %>
+    <%= render "shared/post_card/published_palette", post: post %>
+  <% end %>
 </div>

--- a/app/views/shared/post_card/_draft_palette.html.erb
+++ b/app/views/shared/post_card/_draft_palette.html.erb
@@ -2,16 +2,16 @@
 <div class="max-w-[720px]">
   <div class="relative flex w-full max-w-[26rem] h-[29rem] flex-col rounded-xl bg-white bg-clip-border text-gray-700 shadow-lg">
     <div class="w-96 h-56 flex relative mx-4 mt-8 overflow-hidden text-white shadow-xl rounded-md bg-blue-gray-500 bg-clip-border shadow-blue-gray-500/40">
-      <% ratio = @post.ratio.split(','); @post.color_count.times do |i| %>
-        <div style="width: <%= ratio[i]%>%; background-color: <%= @colors[i].hex_code %>" class="h-full bg-gray-400"></div>
+      <% ratio = post.ratio.split(','); colors = post.colors; post.color_count.times do |i| %>
+        <div style="width: <%= ratio[i]%>%; background-color: <%= colors[i].hex_code %>" class="h-full bg-gray-400"></div>
       <% end %>
     </div>
     <div class="p-6">
       <div class="flex items-center justify-between"> <%# タイトルとゴミ箱ボタン用 %>
           <h5 class="block font-sans text-2xl antialiased font-medium leading-snug tracking-normal text-blue-gray-900">
-            <%= @post.title %>
+            <%= post.title %>
           </h5>
-          <%= link_to post_path(@post), data: { turbo_method: :delete, turbo_confirm: "下書きを削除します。よろしいですか？"},  class:"mr-3" do %>
+          <%= link_to post_path(post), data: { turbo_method: :delete, turbo_confirm: "下書きを削除します。よろしいですか？"},  class:"mr-3" do %>
             <svg xmlns="http://www.w3.org/2000/svg"  class="size-10 transition-all duration-500 ease-out hover:scale-110" viewBox="0 0 24 24" fill="currentColor"><path d="M17 6H22V8H20V21C20 21.5523 19.5523 22 19 22H5C4.44772 22 4 21.5523 4 21V8H2V6H7V3C7 2.44772 7.44772 2 8 2H16C16.5523 2 17 2.44772 17 3V6ZM18 8H6V20H18V8ZM9 11H11V17H9V11ZM13 11H15V17H13V11ZM9 4V6H15V4H9Z"></path></svg>
           <% end %>
       </div>
@@ -22,8 +22,9 @@
           </g>
         </svg>
         <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
-          <%= @post.user.name %>
+          <%= post.user.name %>
         </p>
+        <div class="ml-1 size-2 rounded-full bg-green-400"></div> <%# 自作のパレット識別用 %>
       </div>
 
       <div class="flex items-center gap-2 mt-2"> <%# 公開日時用 %>
@@ -33,13 +34,13 @@
         </span>
         <div class="bg-gray-100 text-gray-800 text-xs font-medium flex gap-1 items-center rounded-sm dark:bg-gray-700 dark:text-gray-400">
           <svg xmlns="http://www.w3.org/2000/svg" class="size-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20ZM13 12H17V14H11V7H13V12Z"></path></svg>
-          <p><%= @post.updated_at.strftime("%Y-%m-%d") %><p>
+          <p><%= post.updated_at.strftime("%Y-%m-%d") %><p>
         </div> <%# 作成日時用 %>
       </div>
 
     </div>
     <div class="px-6">
-      <%= link_to edit_post_path(@post), class:"block w-full select-none rounded-lg bg-gray-900 py-3.5 px-7 text-center align-middle font-sans text-sm font-bold uppercase text-white shadow-md shadow-gray-900/10 transition-all hover:shadow-lg hover:shadow-gray-900/20 focus:opacity-[0.85] focus:shadow-none active:opacity-[0.85] active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none" do %>
+      <%= link_to edit_post_path(post), class:"block w-full select-none rounded-lg bg-gray-900 py-3.5 px-7 text-center align-middle font-sans text-sm font-bold uppercase text-white shadow-md shadow-gray-900/10 transition-all hover:shadow-lg hover:shadow-gray-900/20 focus:opacity-[0.85] focus:shadow-none active:opacity-[0.85] active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none" do %>
         <div class="flex gap-1 items-center justify-center">
           <svg xmlns="http://www.w3.org/2000/svg" class="size-6" viewBox="0 0 24 24" fill="currentColor"><path d="M16.7574 2.99678L14.7574 4.99678H5V18.9968H19V9.23943L21 7.23943V19.9968C21 20.5491 20.5523 20.9968 20 20.9968H4C3.44772 20.9968 3 20.5491 3 19.9968V3.99678C3 3.4445 3.44772 2.99678 4 2.99678H16.7574ZM20.4853 2.09729L21.8995 3.5115L12.7071 12.7039L11.2954 12.7064L11.2929 11.2897L20.4853 2.09729Z"></path></svg>
           <p>編集する</p>

--- a/app/views/shared/post_card/_my_published_palette.html.erb
+++ b/app/views/shared/post_card/_my_published_palette.html.erb
@@ -2,33 +2,32 @@
 <div class="max-w-[720px]">
   <div class="relative flex w-full max-w-[26rem] h-[29rem] flex-col rounded-xl bg-white bg-clip-border text-gray-700 shadow-lg">
     <div class="w-96 h-56 flex justify-center items-center mx-4 mt-8 text-white shadow-xl rounded-md bg-blue-gray-500 bg-clip-border shadow-blue-gray-500/40">
-      <% ratio = @post.ratio.split(','); @post.color_count.times do |i| %>
-        <div style="width: <%= ratio[i]%>%; background-color: <%= @colors[i].hex_code %>" class="h-full bg-gray-400"></div>
+      <% ratio = post.ratio.split(','); colors = post.colors; post.color_count.times do |i| %>
+        <div style="width: <%= ratio[i]%>%; background-color: <%= colors[i].hex_code %>" class="h-full bg-gray-400"></div>
       <% end %>
     </div>
     <div class="p-6">
       <div class="flex items-center justify-between"> <%# タイトルといいね用 %>
         <h5 class="block font-sans text-2xl antialiased font-medium leading-snug tracking-normal text-blue-gray-900">
-            <%= @post.title %>
+            <%= post.title %>
         </h5>
         <div class="flex mr-3 items-end">
           <button type="button" disabled>
-            <svg xmlns="http://www.w3.org/2000/svg" class="size-10" viewBox="0 0 24 24" fill="currentColor"><path d="M12.001 4.52853C14.35 2.42 17.98 2.49 20.2426 4.75736C22.5053 7.02472 22.583 10.637 20.4786 12.993L11.9999 21.485L3.52138 12.993C1.41705 10.637 1.49571 7.01901 3.75736 4.75736C6.02157 2.49315 9.64519 2.41687 12.001 4.52853ZM18.827 6.1701C17.3279 4.66794 14.9076 4.60701 13.337 6.01687L12.0019 7.21524L10.6661 6.01781C9.09098 4.60597 6.67506 4.66808 5.17157 6.17157C3.68183 7.66131 3.60704 10.0473 4.97993 11.6232L11.9999 18.6543L19.0201 11.6232C20.3935 10.0467 20.319 7.66525 18.827 6.1701Z"></path></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" class="size-10 cursor-not-allowed" viewBox="0 0 24 24" fill="currentColor"><path d="M12.001 4.52853C14.35 2.42 17.98 2.49 20.2426 4.75736C22.5053 7.02472 22.583 10.637 20.4786 12.993L11.9999 21.485L3.52138 12.993C1.41705 10.637 1.49571 7.01901 3.75736 4.75736C6.02157 2.49315 9.64519 2.41687 12.001 4.52853ZM18.827 6.1701C17.3279 4.66794 14.9076 4.60701 13.337 6.01687L12.0019 7.21524L10.6661 6.01781C9.09098 4.60597 6.67506 4.66808 5.17157 6.17157C3.68183 7.66131 3.60704 10.0473 4.97993 11.6232L11.9999 18.6543L19.0201 11.6232C20.3935 10.0467 20.319 7.66525 18.827 6.1701Z"></path></svg>
           </button>
-          <div class="select-none"><%= @post.likes.length %></div>
+          <div class="select-none"><%= post.likes.length %></div>
         </div>
       </div>
-      <div class="flex items-center gap-2"> <%# 作成者用 %>
-        <div class="flex items-center gap-1"> <%# 作成者 %>
-          <svg class="size-5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 256 256" xml:space="preserve">
-            <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(1.4065934065934016 1.4065934065934016) scale(2.81 2.81)">
-              <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
-            </g>
-          </svg>
-          <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
-            <%= @post.user.name %>
-          </p>
-        </div>
+      <div class="flex items-center gap-1"> <%# 作成者 %>
+        <svg class="size-5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 256 256" xml:space="preserve">
+          <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(1.4065934065934016 1.4065934065934016) scale(2.81 2.81)">
+            <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
+          </g>
+        </svg>
+        <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
+          <%= post.user.name %>
+        </p>
+        <div class="ml-1 size-2 rounded-full bg-green-400"></div> <%# 自作のパレット識別用 %>
       </div>
       <div class="flex items-center gap-2 mt-2"> <%# 公開日時用 %>
         <span class="inline-flex items-center gap-x-1 py-1 px-2 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-800/30 dark:text-blue-500"> <%# https://preline.co/docs/badge.html %>
@@ -37,13 +36,15 @@
         </span>
         <div class="bg-gray-100 text-gray-800 text-xs font-medium flex gap-1 items-center rounded-sm dark:bg-gray-700 dark:text-gray-400">
           <svg xmlns="http://www.w3.org/2000/svg" class="size-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20ZM13 12H17V14H11V7H13V12Z"></path></svg>
-          <p><%= @post.updated_at.strftime("%Y-%m-%d") %><p>
+          <p><%= post.updated_at.strftime("%Y-%m-%d") %><p>
         </div> <%# 作成日時用 %>
       </div>
     </div>
-    <div class="relative">
-      <div class="absolute right-7 -bottom-2"><%# 詳細ページ矢印用 %>
-        <svg xmlns="http://www.w3.org/2000/svg" class="opacity-80 transition-all duration-500 ease-out hover:scale-125 hover:opacity-100 size-10 mr-4" viewBox="0 0 24 24" fill="currentColor"><path d="M16.1716 10.9999L10.8076 5.63589L12.2218 4.22168L20 11.9999L12.2218 19.778L10.8076 18.3638L16.1716 12.9999H4V10.9999H16.1716Z"></path></svg>
+    <div class="px-6">
+      <div class="flex items-center justify-end"><%# 詳細ページ矢印用 %>
+        <div>
+          <svg xmlns="http://www.w3.org/2000/svg" class="opacity-80 transition-all duration-500 ease-out hover:scale-125 hover:opacity-100 size-10 mr-4" viewBox="0 0 24 24" fill="currentColor"><path d="M16.1716 10.9999L10.8076 5.63589L12.2218 4.22168L20 11.9999L12.2218 19.778L10.8076 18.3638L16.1716 12.9999H4V10.9999H16.1716Z"></path></svg>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/shared/post_card/_published_palette.html.erb
+++ b/app/views/shared/post_card/_published_palette.html.erb
@@ -2,14 +2,14 @@
 <div class="max-w-[720px]">
   <div class="relative flex w-full max-w-[26rem] h-[29rem] flex-col rounded-xl bg-white bg-clip-border text-gray-700 shadow-lg">
     <div class="w-96 h-56 flex justify-center items-center mx-4 mt-8 text-white shadow-xl rounded-md bg-blue-gray-500 bg-clip-border shadow-blue-gray-500/40">
-      <% ratio = @post.ratio.split(','); @post.color_count.times do |i| %>
-        <div style="width: <%= ratio[i]%>%; background-color: <%= @colors[i].hex_code %>" class="h-full bg-gray-400"></div>
+      <% ratio = post.ratio.split(','); colors = post.colors; post.color_count.times do |i| %>
+        <div style="width: <%= ratio[i]%>%; background-color: <%= colors[i].hex_code %>" class="h-full bg-gray-400"></div>
       <% end %>
     </div>
     <div class="p-6">
       <div class="flex items-center justify-between"> <%# タイトルといいね用 %>
         <h5 class="block font-sans text-2xl antialiased font-medium leading-snug tracking-normal text-blue-gray-900">
-          <%= @post.title %>
+          <%= post.title %>
         </h5> <%# いいねボタン %>
 
         <div class="flex flex-row items-end"> <%# いいねボタン %>
@@ -17,25 +17,24 @@
             <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="size-10" viewBox="0 0 24 24" fill="currentColor"><path d="M12.001 4.52853C14.35 2.42 17.98 2.49 20.2426 4.75736C22.5053 7.02472 22.583 10.637 20.4786 12.993L11.9999 21.485L3.52138 12.993C1.41705 10.637 1.49571 7.01901 3.75736 4.75736C6.02157 2.49315 9.64519 2.41687 12.001 4.52853ZM18.827 6.1701C17.3279 4.66794 14.9076 4.60701 13.337 6.01687L12.0019 7.21524L10.6661 6.01781C9.09098 4.60597 6.67506 4.66808 5.17157 6.17157C3.68183 7.66131 3.60704 10.0473 4.97993 11.6232L11.9999 18.6543L19.0201 11.6232C20.3935 10.0467 20.319 7.66525 18.827 6.1701Z"></path></svg>
             <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="size-10 fill-orange-400" viewBox="0 0 24 24" fill="currentColor"><path d="M12.001 4.52853C14.35 2.42 17.98 2.49 20.2426 4.75736C22.5053 7.02472 22.583 10.637 20.4786 12.993L11.9999 21.485L3.52138 12.993C1.41705 10.637 1.49571 7.01901 3.75736 4.75736C6.02157 2.49315 9.64519 2.41687 12.001 4.52853Z"></path></svg>
           </button>
-          <div class="select-none"><%= @post.likes.length %></div>
+          <div class="select-none"><%= post.likes.length %></div>
         </div>
       </div>
-      <div class="flex items-center gap-2"> <%# 作成者用 %>
-        <div class="flex items-center gap-1"> <%# 作成者 %>
-          <svg class="size-5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 256 256" xml:space="preserve">
-            <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(1.4065934065934016 1.4065934065934016) scale(2.81 2.81)">
-              <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
-            </g>
-          </svg>
-          <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
-            <%= @post.user.name %>
-          </p>
-        </div>
+      <div class="flex items-center gap-1"> <%# 作成者 %>
+        <svg class="size-5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 256 256" xml:space="preserve">
+          <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(1.4065934065934016 1.4065934065934016) scale(2.81 2.81)">
+            <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
+          </g>
+        </svg>
+        <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
+          <%= post.user.name %>
+        </p>
       </div>
+
       <div class="flex items-center gap-2 mt-2"> <%# 状態タグと公開日時用 %>
         <div class="bg-gray-100 text-gray-800 text-xs font-medium flex gap-1 items-center rounded-sm dark:bg-gray-700 dark:text-gray-400">
           <svg xmlns="http://www.w3.org/2000/svg" class="size-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20ZM13 12H17V14H11V7H13V12Z"></path></svg>
-          <p><%= @post.updated_at.strftime("%Y-%m-%d") %><p>
+          <p><%= post.updated_at.strftime("%Y-%m-%d") %><p>
         </div> <%# 作成日時用 %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     confirmations: "users/confirmations"
   }
 
-  root to: "top#index"
+  root to: "posts#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # postsコントローラーのルーティング


### PR DESCRIPTION
## 実施内容
- 下書きや公開状態で保存したパレットを削除する機能を実装しました。
- Postコントローラーのdestroyメソッドに該当する処理を記載しました。

編集・作成した主なファイルは以下の通りです。
- `app/views/shared/post_card/_draft_palette.html.erb`
    - 下書きパレットの一覧表示用パーシャルファイル。削除ボタンを押した際にdestroyメソッドを実行されるよう修正。
- `app/views/posts/new.html.erb`
    - パレット新規作成画面のviewファイル。パレットを保存せずに終了するボタンと、削除するボタンの作成。
- `app/controllers/posts_controller.rb`

## 備考
公開済みのパレットの削除方法が詳細ページでのボタンしか設置していないため、一覧表示のコンポーネントでも削除できるように実装する必要あり。

## 実施タスク
close #21