### PR TITLE
feat:フラッシュメッセージのスタイル修正

### DIFF
--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,42 +1,42 @@
-<% flash.each do |message_type, message| %>
-  <% if message_type == "notice" %>
-    <div x-data="{ alertIsVisible: true }" x-show="alertIsVisible" class="relative w-full overflow-hidden rounded-sm border border-green-500 bg-white text-neutral-600 dark:bg-neutral-950 dark:text-neutral-300" role="alert" x-transition:leave="transition ease-in duration-300" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-90">
-        <div class="flex w-full items-center gap-2 bg-green-500/10 p-4">
-            <div class="bg-green-500/15 text-green-500 rounded-full p-1" aria-hidden="true">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-6" aria-hidden="true">
-                    <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-                </svg>
-            </div>
-            <div class="ml-2">
-                <h3 class="text-sm font-semibold text-green-500">Successfully</h3>
+<div class="z-50 fixed top-24 right-10 min-w-96">
+  <% flash.each do |message_type, message| %>
+    <% if message_type == "notice" %>
+      <div x-data="{ alertIsVisible: true }" x-show="alertIsVisible" class="relative w-full overflow-hidden rounded-sm border border-green-500 bg-white text-neutral-600 dark:bg-neutral-950 dark:text-neutral-300" role="alert" x-transition:leave="transition ease-in duration-300" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-90">
+          <div class="flex w-full items-center gap-2 bg-green-500/10 p-4">
+              <div class="bg-green-500/15 text-green-500 rounded-full p-1" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-6" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
+                  </svg>
+              </div>
+              <div class="ml-2">
                 <p class="text-xs font-medium sm:text-sm"><%= message %></p>
-            </div>
-            <button type="button" @click="alertIsVisible = false" class="ml-auto" aria-label="dismiss alert">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" fill="none" stroke-width="2.5" class="w-4 h-4 shrink-0">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                </svg>
-            </button>
-        </div>
-    </div> <%# 成功時のフラッシュメッセージ %>
-  <% elsif message_type == "alert" %>
-    <!-- danger Alert -->
-    <div x-data="{ alertIsVisible: true }" x-show="alertIsVisible" class="relative w-full overflow-hidden rounded-sm border border-red-500 bg-white text-neutral-600 dark:bg-neutral-950 dark:text-neutral-300" role="alert" x-transition:leave="transition ease-in duration-300" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-90">
-        <div class="flex w-full items-center gap-2 bg-red-500/10 p-4">
-            <div class="bg-red-500/15 text-red-500 rounded-full p-1" aria-hidden="true">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-6" aria-hidden="true">
-                    <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM8.28 7.22a.75.75 0 0 0-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 1 0 1.06 1.06L10 11.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L11.06 10l1.72-1.72a.75.75 0 0 0-1.06-1.06L10 8.94 8.28 7.22Z" clip-rule="evenodd" />
-                </svg>
-            </div>
-            <div class="ml-2">
-                <h3 class="text-sm font-semibold text-red-500">Failed</h3>
+              </div>
+              <button type="button" @click="alertIsVisible = false" class="ml-auto" aria-label="dismiss alert">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" fill="none" stroke-width="2.5" class="w-4 h-4 shrink-0">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                  </svg>
+              </button>
+          </div>
+      </div> <%# 成功時のフラッシュメッセージ %>
+    <% elsif message_type == "alert" %>
+      <!-- danger Alert -->
+      <div x-data="{ alertIsVisible: true }" x-show="alertIsVisible" class="relative w-full overflow-hidden rounded-sm border border-red-500 bg-white text-neutral-600 dark:bg-neutral-950 dark:text-neutral-300" role="alert" x-transition:leave="transition ease-in duration-300" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-90">
+          <div class="flex w-full items-center gap-2 bg-red-500/10 p-4">
+              <div class="bg-red-500/15 text-red-500 rounded-full p-1" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-6" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM8.28 7.22a.75.75 0 0 0-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 1 0 1.06 1.06L10 11.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L11.06 10l1.72-1.72a.75.75 0 0 0-1.06-1.06L10 8.94 8.28 7.22Z" clip-rule="evenodd" />
+                  </svg>
+              </div>
+              <div class="ml-2">
                 <p class="text-xs font-medium sm:text-sm"><%= message %></p>
-            </div>
-            <button type="button" @click="alertIsVisible = false" class="ml-auto" aria-label="dismiss alert">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" fill="none" stroke-width="2.5" class="w-4 h-4 shrink-0">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                </svg>
-            </button>
-        </div>
-    </div>
+              </div>
+              <button type="button" @click="alertIsVisible = false" class="ml-auto" aria-label="dismiss alert">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" fill="none" stroke-width="2.5" class="w-4 h-4 shrink-0">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                  </svg>
+              </button>
+          </div>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</div>


### PR DESCRIPTION
## 実施内容
- フラッシュメッセージの位置と挙動を変更しました。


- 変更前
  - フラッシュメッセージが表示されると<%= yield %>の要素ごと下にずれてしまいます。また、スクロールすると、フラッシュメッセージが一緒に動いてくれないため確認できなくなります。
  
![253](https://github.com/user-attachments/assets/60a51962-a446-4f0a-b977-c2ae30dcc38e)

- 変更後 
  - fixedクラス(position: fixed)をつけることでスクリーン全体での固定位置に表示されるよう設定しました。
![233](https://github.com/user-attachments/assets/40d03eb8-a857-4ce5-a07b-fadd2b81cec3)


編集・作成した主なファイルは以下の通りです。
- app/views/shared/_flash_message.html.erb
  - フラッシュメッセージ用のパーシャルファイル。
  - position: fixedを指定したdivを追加。

## 備考

## 実施タスク
close #81 