### PR TITLE
パレット登録時にデフォルトタイトルを保存するための記載追加 #83

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,13 +32,19 @@ class PostsController < ApplicationController
     # input_colors = params[:post][:color].split(',') # colorの入力値を配列の形でinput_colorsに格納する。
     @post.create_colors(input_colors) # create_colorsをpost.rbにメソッド記載。colorテーブルの作成と中間テーブルへの登録を行うためのメソッド。
     if @post.save
+
+      # タイトルが空の場合、デフォルト設定を施したい。
+      if @post.title.blank?
+        @post.update(title: "untitled-#{@post.id}")
+      end
+
       if @post.status == "draft"
         redirect_to user_path(current_user), notice: "下書きを保存しました。" # 作成が成功したら詳細ページへ移動する。
       else
         redirect_to user_path(current_user), notice: "パレットを公開しました。"
       end
     else
-    render :new
+      render :new
     end
   end
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -36,7 +36,7 @@
             <div class="mt-3"> <%# タイトル %>
               <%= f.label :title, "タイトル", class:"font-bold" %>
               <div class="flex gap-1 items-center justify-center">
-                <%= f.text_field :title, placeholder:"パレット名を入力して下さい", value:"untitled", class:"w-80 px-4 py-2 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" %>
+                <%= f.text_field :title, placeholder:"パレット名を入力して下さい", class:"w-80 px-4 py-2 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" %>
               </div>
             </div>
 


### PR DESCRIPTION
## 実施内容
- パレット作成画面でのタイトルを空のまま送信した際に、「untitled-6」のようにパレット自体のidに応じてデフォルトのタイトル名が登録されるように微修正を行いました。

編集・作成した主なファイルは以下の通りです。
- `app/controllers/posts_controller.rb`
    - createメソッドでのsave成功時の次処理を修正。

## 備考


## 実施タスク
close #83 