### PR TITLE
feat:新規会員登録時のデフォルトユーザー名保存機能 #85

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,9 +11,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    super do |resource|
+      if resource.persisted?
+        resource.update(name: "default-name-#{resource.id}")
+      end
+    end
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -37,14 +37,14 @@
                 <p class="font-bold">ユーザーネーム</p>
                 <div class="flex gap-1 items-center justify-center">
                   <div class="w-64 px-4 py-2 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white">
-                    <%= current_user.name.presence || "user-#{current_user.id}" %>
+                    <%= current_user.name %>
                   </div>
                   <div x-data="{modalIsOpen: false}"> <%# ユーザーネーム変更ボタン %>
                       <button x-on:click="modalIsOpen = true" type="button" class="flex items-center">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="cursor-pointer size-6 opacity-70 hover:opacity-100 transition-opacity" fill="currentColor"><path d="M5 18.89H6.41421L15.7279 9.57627L14.3137 8.16206L5 17.4758V18.89ZM21 20.89H3V16.6473L16.435 3.21231C16.8256 2.82179 17.4587 2.82179 17.8492 3.21231L20.6777 6.04074C21.0682 6.43126 21.0682 7.06443 20.6777 7.45495L9.24264 18.89H21V20.89ZM15.7279 6.74785L17.1421 8.16206L18.5563 6.74785L17.1421 5.33363L15.7279 6.74785Z"></path></svg> <%# https://remixicon.com/icon/edit-2-line %>
                       </button>
                       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-                        <div x-cloak x-show="modalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="modalIsOpen" x-on:keydown.esc.window="modalIsOpen = false" x-on:click.self="modalIsOpen = false" class="fixed inset-0 z-30 flex justify-center bg-black/20 p-4 pb-8 backdrop-blur-md items-center lg:p-8" role="dialog" aria-modal="true" aria-labelledby="defaultModalTitle">
+                        <div x-data="{ userName: '<%= current_user.name %>' }" x-cloak x-show="modalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="modalIsOpen" x-on:keydown.esc.window="modalIsOpen = false" x-on:click.self="modalIsOpen = false" class="fixed inset-0 z-30 flex justify-center bg-black/20 p-4 pb-8 backdrop-blur-md items-center lg:p-8" role="dialog" aria-modal="true" aria-labelledby="defaultModalTitle">
                             <!-- Modal Dialog -->
                             <div x-show="modalIsOpen" x-transition:enter="transition ease-out duration-200 delay-100 motion-reduce:transition-opacity" x-transition:enter-start="opacity-0 scale-50" x-transition:enter-end="opacity-100 scale-100" class="flex max-w-lg flex-col gap-4 overflow-hidden rounded-sm border border-neutral-300 bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300">
                                 <!-- Dialog Header -->
@@ -60,13 +60,24 @@
                                 <div class="m-5 px-4 py-8 w-96">
                                   <div> <%# ネーム入力欄%>
                                     <%= f.label :name, "ユーザーネーム", class:"font-bold mb-1" %>
-                                    <%= f.text_field :name, value: current_user.name.presence || '', placeholder: "アプリ内で使用するネームを登録してください", class: "w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" %>
+                                    <%= f.text_field :name, "x-model": "userName", placeholder: "アプリ内で使用するネームを登録してください", class: "w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" %>
                                   </div>
                                 </div>
                                 <!-- Dialog Footer -->
                                 <div class="flex flex-col-reverse gap-2 border-t border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20 sm:flex-row sm:items-center justify-end">
                                     <button x-on:click="modalIsOpen = false" type="button" class="whitespace-nowrap rounded-sm px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-600 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:text-neutral-300 dark:focus-visible:outline-white underline">キャンセル</button>
-                                    <%= f.submit "変更する", class: "whitespace-nowrap rounded-sm bg-black border border-black dark:border-white px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-100 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:bg-white dark:text-black dark:focus-visible:outline-white" %>
+                                    <div :class="{ 'opacity-30 cursor-not-allowed pointer-events-none': userName.trim().length === 0 }">
+
+
+                                    <button
+                                      type="submit"
+                                      x-bind:disabled="userName.trim().length === 0"
+                                      class="whitespace-nowrap rounded-sm bg-black border border-black dark:border-white px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-100 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:bg-white dark:text-black dark:focus-visible:outline-white">
+                                      変更する
+                                    </button>
+
+
+                                    </div>
                                 </div>
                             </div>
                         </div> <%# ↑ユーザーネーム変更モーダル中身 %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -38,7 +38,7 @@ en:
       updated_not_active: "Your password has been changed successfully."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
+      signed_up: "新規登録に成功しました！ユーザー名は「プロフィール設定」から設定・変更可能です。"
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."


### PR DESCRIPTION
## 実施内容
新規会員の時点ではユーザー名の入力は求めず、デフォルトのユーザー名を自動で割り振った上で、必要に応じてユーザー自らが設定画面にて変更を行うといった構成を考えております。これらを実装するための機能として、下記の3つを実装しました。
- 会員登録時、default_user_6(6はuser_id)といったようにidに基づいて動的なデフォルト名が登録されるようにdeviceのコントローラ内処理を修正しました。
- 会員登録完了後、「プロフィール設定画面からユーザーネームの変更が行える」旨のフラッシュメッセージが表示されるようにしました。
- 実際に変更ができるフォームでは、空文字では更新ボタンが押せず、フォームの送信や変更が行えないようフロントのバリデーションをAlpine.jsを用いて実装しました。

編集・作成した主なファイルは以下の通りです。
- `app/views/users/registrations/edit.html.erb`
    - プロフィール設定画面のユーザー名変更フォームにて、空文字での更新ができないよう設定。
- `app/controllers/users/registrations_controller.rb`
    - 新規会員登録成功時にデフォルトのユーザー名が登録されるよう処理を記載。

## 備考
- 新規会員登録後に表示される日本語のフラッシュメッセージを`config/locales/devise.en.yml`に一時的に書いてしまっている状態。ja関連のファイルを作成し、書き換える必要がある。

## 実施タスク
close #85 