### PR TITLE
feat:表示されるパレットを最新順に変更 #89

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,24 +4,24 @@ class PostsController < ApplicationController
       redirect_to top_index_path
       return
     end
-    @pagy, @posts = pagy(Post.where(status: "published"))
+    @pagy, @posts = pagy(Post.where(status: "published").order(created_at: :desc))
   end
 
   def new
-    # @color_candidate = [
-    #   [ "#303967", "#e60012", "#ffe200" ],
-    #   [ "#34485e", "#3c7d9b", "#5b9f8a" ],
-    #   [ "#dcc58c", "#db3a09", "#478657" ],
-    #   [ "#4f85a6", "#79a7d9", "#d8dbd9" ],
-    #   [ "#7c2e1e", "#b19962", "#2a4743" ],
-    #   [ "#eae4d1", "#6c8650", "#a87570" ],
-    #   [ "#b32425", "#fffde1", "#d6b845", "#150c15" ],
-    #   [ "#150c15", "#9a1117", "#917c50", "#bbe3f5", "#da6a38" ],
-    #   [ "#8b272b", "#e5006a" ],
-    #   [ "#462e2e", "#cfaa2a" ],
-    #   [ "#fff5e0", "#1a0b08" ],
-    #   [ "#494544", "#c41a30", "#bac8c6" ]
-    # ]
+    @default_palette = [
+      [ "#303967", "#e60012", "#ffe200" ],
+      [ "#34485e", "#3c7d9b", "#5b9f8a" ],
+      [ "#dcc58c", "#db3a09", "#478657" ],
+      [ "#4f85a6", "#79a7d9", "#d8dbd9" ],
+      [ "#7c2e1e", "#b19962", "#2a4743" ],
+      [ "#eae4d1", "#6c8650", "#a87570" ],
+      [ "#b32425", "#fffde1", "#d6b845", "#150c15" ],
+      [ "#150c15", "#9a1117", "#917c50", "#bbe3f5", "#da6a38" ],
+      [ "#8b272b", "#e5006a" ],
+      [ "#462e2e", "#cfaa2a" ],
+      [ "#fff5e0", "#1a0b08" ],
+      [ "#494544", "#c41a30", "#bac8c6" ]
+    ].sample
     @post = Post.new
   end
 

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,5 +1,5 @@
 class TopController < ApplicationController
   def index
-    @posts = Post.where(status: "published").limit(10)
+    @posts = Post.where(status: "published").order(created_at: :desc).limit(10)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,10 +7,10 @@ class UsersController < ApplicationController
       return
     end
 
-    published_posts = Post.where(user_id: @user.id, status: "published")
+    published_posts = Post.where(user_id: @user.id, status: "published").order(created_at: :desc)
     @my_page_published_posts = published_posts.limit(5)
     @published_count = published_posts.count
-    draft_posts = Post.where(user_id: @user.id, status: "draft")
+    draft_posts = Post.where(user_id: @user.id, status: "draft").order(created_at: :desc)
     @my_page_draft_posts = draft_posts.limit(5)
     @draft_count = draft_posts.count
   end

--- a/app/javascript/range_slider.js
+++ b/app/javascript/range_slider.js
@@ -13,16 +13,6 @@ document.addEventListener("turbo:load", function() {
   // ツールチップを実装するための定義。下のnoUiSlider.createのtooltips: toolTipsで参照する。
   window.toolTipsSetting = [false];
 
-  // // 保存ボタンが押された時に下書き保存と公開を切り替えるための記載。
-  // const publishedButton = document.getElementById('published_button');
-  // const draftButton = document.getElementById('draft_button');
-  // publishedButton.addEventListener('click', () => {
-  //   document.getElementById('post_status').value = 'published';
-  // });
-  // draftButton.addEventListener('click', () => {
-  //   document.getElementById('post_status').value = 'draft';
-  // });
-
   window.toolTipsUpdate = function(){
     window.toolTipsSetting = [false];
     for (let i=1; i < window.colors.length + 1; i++) {

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,5 @@
 <!-- source:https://codepen.io/owaiswiz/pen/jOPvEPB -->
-<% @colors = [ "#303967", "#e60012", "#ffe200" ] %>
+<% @colors = @default_palette %>
 <div id="tag-info" data-json=<%= @colors.to_json %>></div>
 <div x-data="{ choice: false, setting: <%= @colors.size %> }" class= "min-h-fit py-10 bg-gray-100 text-gray-900 flex items-center justify-center"> <%# フォーム画面の土台枠外span %>
   <div class="mx-20 my-5">


### PR DESCRIPTION
## 実施内容
パレットの一覧が表示される各画面にて、デフォルトの並びが作成日時の新しい順で表示されるように変更しました。


編集・作成した主なファイルは以下の通りです。
- `app/controllers/posts_controller.rb`
    - 投稿一覧画面のパレットを最新順で表示されるようクエリメソッドを追加。
- `app/controllers/top_controller.rb`
    - 未ログイン時に最新10件のパレットがトップ画面に表示されるよう変更。
- `app/controllers/users_controller.rb`
    - マイページにて下書きおよび公開済みのパレットが最新順で表示されるよう変更。

## 備考


## 実施タスク
close #89 