### PR TITLE
画面遷移微調整

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -41,7 +41,7 @@ class PostsController < ApplicationController
       if @post.status == "draft"
         redirect_to user_path(current_user), notice: "下書きを保存しました。" # 作成が成功したら詳細ページへ移動する。
       else
-        redirect_to user_path(current_user), notice: "パレットを公開しました。"
+        redirect_to post_path(@post), notice: "パレットを公開しました。"
       end
     else
       render :new, status: :unprocessable_entity

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -28,9 +28,9 @@
                       <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
                     </g>
                   </svg>
-                  <p class="block font-sans text-lg antialiased font-light leading-relaxed hover:underline text-black">
+                  <%= link_to user_path(post.user_id), class:"block font-sans text-lg antialiased font-light leading-relaxed hover:underline text-black" do %>
                     <%= post.user.name %>
-                  </p>
+                  <% end %>
                 </div>
                 <!-- End ユーザー -->
 

--- a/app/views/shared/post_card/_draft_palette.html.erb
+++ b/app/views/shared/post_card/_draft_palette.html.erb
@@ -20,9 +20,9 @@
           <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
         </g>
       </svg>
-      <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
+      <%= link_to user_path(post.user_id), class:"block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700" do %>
         <%= post.user.name %>
-      </p>
+      <% end %>
       <div class="ml-1 size-2 rounded-full bg-green-400"></div> <%# 自作のパレット識別用 %>
     </div>
 

--- a/app/views/shared/post_card/_my_published_palette.html.erb
+++ b/app/views/shared/post_card/_my_published_palette.html.erb
@@ -23,9 +23,9 @@
           <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
         </g>
       </svg>
-      <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
+      <%= link_to user_path(post.user_id), class:"block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700" do %>
         <%= post.user.name %>
-      </p>
+      <% end %>
       <div class="ml-1 size-2 rounded-full bg-green-400"></div> <%# 自作のパレット識別用 %>
     </div>
     <div class="flex items-center gap-2 mt-2"> <%# 公開日時用 %>

--- a/app/views/shared/post_card/_published_palette.html.erb
+++ b/app/views/shared/post_card/_published_palette.html.erb
@@ -25,9 +25,9 @@
             <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
           </g>
         </svg>
-        <p class="block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700">
+        <%= link_to user_path(post.user_id), class:"block font-sans text-base antialiased font-light leading-relaxed hover:underline text-gray-700" do %>
           <%= post.user.name %>
-        </p>
+        <% end %>
       </div>
 
       <div class="flex items-center gap-2 mt-2"> <%# 状態タグと公開日時用 %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -51,7 +51,7 @@
                         name="user[password]"
                         id="user_password"
                         class="w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" 
-                        placeholder="8文字以上・半角英数字記号"
+                        placeholder="6文字以上・半角英数字記号"
                     />
                     <button type="button" class="absolute right-2 bg-transparent flex items-center justify-center hover:text-blue-600" @click="show = !show">
                         <svg x-show="!show" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -66,7 +66,7 @@
                       name="user[password]"
                       id="user_password"
                       class="w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white"
-                      placeholder="8文字以上・半角英数字記号"
+                      placeholder="パスワードを入力してください"
                   />
                   <button type="button" class="absolute right-2 bg-transparent flex items-center justify-center hover:text-blue-600" @click="show = !show">
                       <svg x-show="!show" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## 実施内容
- パレット投稿時の画面遷移先にパレット詳細画面を設定しました。
- パレット一覧や詳細画面に表示されるユーザーネームをクリックすると、ユーザーの詳細ページに遷移するよう設定しました。