### PR TITLE
Googleアナリティクスで発行したトラッキングコードの反映用デプロイ

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,16 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-C7R1KN04E8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-C7R1KN04E8');
+    </script>
+
     <%= yield :head %>
 
     <link rel="manifest" href="/manifest.json">


### PR DESCRIPTION
## 実施内容
- デプロイしたアプリを解析するためのGoogleアナリティクス設定にて、アプリと紐づけるためのトラッキングコードを共通viewファイルに記載しました。デプロイ先にコードを反映し、実際の接続を確認するためのPRとなります。

編集・作成した主なファイルは以下の通りです。
- app/views/layouts/application.html.erb
  - headタグ内にgoogleアナリティクスにて発行したトラッキングコードを記載しました。

## 備考

## 実施タスク
close #140 