### PR TITLE
feat:新規登録画面でハンドルネームの任意入力対応化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   include Pagy::Backend
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,7 +14,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     super do |resource|
       if resource.persisted?
-        resource.update(name: "default-name-#{resource.id}")
+        resource.update(name: params[:user][:name].presence || "default-name-#{resource.id}")
       end
     end
   end

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -7,7 +7,7 @@
     <div class="lg:w-1/2 xl:w-5/12 p-6 sm:p-12"> <%# フォーム本体枠 %>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <div class="flex mx-auto items-center justify-center w-full"> <%# アプリロゴ欄 %>
-          <p class="text-xl xl:text-2xl">Coloratio</p>
+          <%#<p class="text-xl xl:text-2xl">Coloratio</p> %>
         </div>
         <div class="mt-10 flex flex-col items-center"> <%# 「会員登録」以下のフォーム部分 %>
             <h1 class="text-2xl xl:text-3xl font-bold"> <%# 太文字「会員登録」 %>
@@ -21,24 +21,40 @@
                   <%= render "users/shared/error_messages", resource: resource %>
                 </div>
 
-                <span class="hidden"> <%# ユーザーネーム入力欄(今のところ非表示) %>
-                  <p class="font-bold mb-1">ユーザーネーム</p>
-                  <input
-                      class="w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white"
-                      type="email" placeholder="アプリ内で使用するネームを登録してください"
-                  />
-                </span>
+                <div x-data="{ name: '' }" class="mt-10"> <%# ハンドルネーム入力欄 %>
+                  <div class="mb-1 flex gap-1 items-center"> <%# ハンドルネームラベル用 %>
+                    <%= f.label :name, "ハンドルネーム(任意)", class:"font-bold", autocomplete:"off" %>
 
-                <div class="mt-10"> <%# メールアドレス入力欄(device対応済み) %>
+                    <div class="relative w-fit"> <%# ハンドルネームツールチップ %>
+                        <svg class="size-5 fill-gray-400 peer cursor-pointer" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM11 15V17H13V15H11ZM13 13.3551C14.4457 12.9248 15.5 11.5855 15.5 10C15.5 8.067 13.933 6.5 12 6.5C10.302 6.5 8.88637 7.70919 8.56731 9.31346L10.5288 9.70577C10.6656 9.01823 11.2723 8.5 12 8.5C12.8284 8.5 13.5 9.17157 13.5 10C13.5 10.8284 12.8284 11.5 12 11.5C11.4477 11.5 11 11.9477 11 12.5V14H13V13.3551Z"></path></svg>
+                        <div id="tooltipExample" class="pointer-events-none absolute bottom-full mb-2 left-1/2 -translate-x-1/2 z-10 flex w-80 flex-col gap-1 rounded-sm bg-neutral-950 p-2.5 text-xs text-neutral-300 opacity-0 transition-all ease-out peer-hover:opacity-100 peer-focus:opacity-100 dark:bg-white dark:text-neutral-600" role="tooltip">
+                            <span class="text-sm font-medium text-white dark:text-neutral-900">ハンドルネームについて</span>
+                            <ul>
+                            <li>・他のユーザーに表示されます。</li>
+                            <li>・未記入の場合、デフォルトのネームが登録されます。</li>
+                            <li>・後から設定・変更が可能です。</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                  </div>
+
+                  <input x-model="name" class="w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" maxlength="15" size="15" type="text" name="user[name]" id="user_name">
+
+                  <span class="mt-1 text-xs text-gray-500" x-text="`(${name.length}文字/15文字以内)`"></span>
+                </div>
+
+                <div class="mb-1 mt-5"> <%# メールアドレス入力欄(device対応済み) %>
                   <div class="mb-1"> <%# メールアドレスラベル用 %>
                     <label class="font-bold" for="user_email">メールアドレス</label>
                   </div>
                   <%= f.email_field :email,
                     autocomplete: "email",
                     class: "w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white", 
-                    placeholder: "メールアドレスを入力してください"
+                    placeholder: "例：sample@gmail.com"
                   %>
                 </div>
+
 
                 <div> <%# パスワード入力欄 %>
                   <div class="mb-1 mt-5"> <%# パスワードラベル用 %>


### PR DESCRIPTION
## 実施内容
- 新規登録画面にてハンドルネームの任意登録ができるよう入力欄の設置を行いました。
- ハンドルネームは15文字以上入力できないようになっており、入力文字数がリアルタイムで反映されて表示されるようにしました。
![20254325](https://github.com/user-attachments/assets/fa694751-8cd6-400b-9b6a-629e6d7858a7)
- ヒントマークにカーソルを合わせると、ハンドルネームについての備考ツールチップが確認できます。
![20225](https://github.com/user-attachments/assets/ee1ae0cc-0b0a-412d-8f05-3941edbd8fa3)



編集・作成した主なファイルは以下の通りです。
- `app/views/users/registrations/new.html.erb`
    - ハンドルネーム記入欄を追加。
- `app/controllers/application_controller.rb`
    - ユーザー登録時にnameを扱えるよう、ストロングパラメータの記載変更。

## 備考
- ニックネームの重複を許すかどうか。許さないのであれば、フォーム登録時点で既に使用されてるニックネームなのかを確認する必要がある。
- ニックネームが登録されなかった場合、default-user-#{[user.id](http://user.id/)}っていう感じで登録されることになる。重複を許さないのであれば、defalult-user-ってつく名前は名前変更・登録に使用できないようにする必要あり。

## 実施タスク
close #124 