### PR TITLE
feat:プライバシーポリシー・利用規約のモーダル画面実装

### DIFF
--- a/app/views/shared/_privacy_policy_modal.html.erb
+++ b/app/views/shared/_privacy_policy_modal.html.erb
@@ -1,0 +1,26 @@
+<!-- プライバシーポリシーモーダル中身 -->
+<div x-cloak x-show="privacyModalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="privacyModalIsOpen" x-on:keydown.esc.window="privacyModalIsOpen = false" x-on:click.self="privacyModalIsOpen = false" class="fixed inset-0 z-30 flex items-end justify-center bg-black/20 p-4 pb-8 backdrop-blur-md sm:items-center lg:p-8" role="dialog" aria-modal="true" aria-labelledby="defaultModalTitle">
+  <!-- Modal Dialog -->
+  <div x-show="privacyModalIsOpen" x-transition:enter="transition ease-out duration-200 delay-100 motion-reduce:transition-opacity" x-transition:enter-start="opacity-0 translate-y-8" x-transition:enter-end="opacity-100 translate-y-0" class="flex max-w-lg flex-col gap-4 overflow-hidden rounded-sm border border-neutral-300 bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300">
+    <!-- Dialog Header -->
+    <div class="flex items-center justify-between border-b border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20">
+      <h3 id="defaultModalTitle" class="font-semibold tracking-wide text-neutral-900 dark:text-white">プライバシーポリシー</h3>
+    </div>
+    <!-- Dialog Body -->
+    <div class="max-h-96 px-4 py-8 overflow-y-auto overscroll-y-contain">
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+    </div>
+    <!-- Dialog Footer -->
+    <div class="flex flex-col-reverse justify-between gap-2 border-t border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20 sm:flex-row sm:items-center md:justify-end">
+        <button x-on:click="privacyModalIsOpen = false" type="button" class="whitespace-nowrap rounded-sm bg-black border border-black dark:border-white px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-100 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:bg-white dark:text-black dark:focus-visible:outline-white">閉じる</button>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_terms_of_service_modal.html.erb
+++ b/app/views/shared/_terms_of_service_modal.html.erb
@@ -1,0 +1,27 @@
+<!-- 利用規約モーダル中身 -->
+
+<div x-cloak x-show="termsOfServiceModalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="termsOfServiceModalIsOpen" x-on:keydown.esc.window="termsOfServiceModalIsOpen = false" x-on:click.self="termsOfServiceModalIsOpen = false" class="fixed inset-0 z-30 flex items-end justify-center bg-black/20 p-4 pb-8 backdrop-blur-md sm:items-center lg:p-8" role="dialog" aria-modal="true" aria-labelledby="defaultModalTitle">
+  <!-- Modal Dialog -->
+  <div x-show="termsOfServiceModalIsOpen" x-transition:enter="transition ease-out duration-200 delay-100 motion-reduce:transition-opacity" x-transition:enter-start="opacity-0 translate-y-8" x-transition:enter-end="opacity-100 translate-y-0" class="flex max-w-lg flex-col gap-4 overflow-hidden rounded-sm border border-neutral-300 bg-white text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300">              
+    <!-- Dialog Header -->
+    <div class="flex items-center justify-between border-b border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20">
+        <h3 id="defaultModalTitle" class="font-semibold tracking-wide text-neutral-900 dark:text-white">利用規約</h3>
+    </div>
+    <!-- Dialog Body -->
+    <div class="max-h-96 px-4 py-8 overflow-y-auto overscroll-y-contain">
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+        <p>As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.</p>
+    </div>
+    <!-- Dialog Footer -->
+    <div class="flex flex-col-reverse justify-between gap-2 border-t border-neutral-300 bg-neutral-50/60 p-4 dark:border-neutral-700 dark:bg-neutral-950/20 sm:flex-row sm:items-center md:justify-end">
+        <button x-on:click="termsOfServiceModalIsOpen = false" type="button" class="whitespace-nowrap rounded-sm bg-black border border-black dark:border-white px-4 py-2 text-center text-sm font-medium tracking-wide text-neutral-100 transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:opacity-100 active:outline-offset-0 dark:bg-white dark:text-black dark:focus-visible:outline-white">閉じる</button>
+    </div>
+  </div>
+</div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -106,18 +106,27 @@
                   </div>
                 </div>
 
-                <div> <%# みなし同意テキスト %>
+                <!-- みなし同意テキスト用 -->
+                <div x-data="{privacyModalIsOpen: false, termsOfServiceModalIsOpen: false}">
                   <p class="mt-8 mb-1 text-xs text-gray-400 text-left">
-                      アカウントを作成すると、
-                      <a href="#" class="text-orange-400 hover:text-orange-600 border-b border-gray-400 border-dotted">
-                        利用規約
-                      </a>
-                      および
-                      <a href="#" class="text-orange-400 hover:text-orange-600 border-b border-gray-400 border-dotted">
-                        プライバシーポリシー
-                      </a>
-                      に同意したとみなされます。
+                    アカウントを作成すると、
+
+                    <!-- 利用規約テキスト -->
+                    <span x-on:click="termsOfServiceModalIsOpen = true" class="cursor-pointer text-orange-400 hover:text-orange-600 border-b border-gray-400 border-dotted">
+                      利用規約
+                    </span>
+
+                    および
+
+                    <!-- プライバシーポリシーテキスト -->
+                    <span x-on:click="privacyModalIsOpen = true" class="cursor-pointer text-orange-400 hover:text-orange-600 border-b border-gray-400 border-dotted">
+                      プライバシーポリシー
+                    </span>
+
+                    に同意したとみなされます。
                   </p>
+                  <%= render 'shared/terms_of_service_modal' %>
+                  <%= render 'shared/privacy_policy_modal' %>
                 </div>
 
                 <div> <%# 同意して登録ボタン %>


### PR DESCRIPTION
## 実施内容
- 会員登録ページにて、「利用規約」「プライバシーポリシー」の文字をそれぞれクリックした際に、画面遷移することなくそのページ内で確認ができるように、モーダルで表示されるように実装しました。
- それぞれモーダル内で本文要素がスクロールできるように実装してあります。
- 内容自体は仮置きの状態です。別タスクにて利用規約とプライバシーポリシーの作成が完了してからこちらのモーダルにも反映させる予定です。
![20265325](https://github.com/user-attachments/assets/9e49e4a0-2f9a-4319-8541-44c4223b4969)


編集・作成した主なファイルは以下の通りです。
- `app/views/shared/_privacy_policy_modal.html.erb`
    - プライバシーポリシーモーダル用のパーシャルファイル
- `app/views/shared/_terms_of_service_modal.html.erb`
    - 利用規約モーダル用のパーシャルファイル

## 備考
- モーダル表示時に裏側の画面要素がスクロールできる状態になってしまってるため、対処する必要がある。
- スクロール連鎖自体はoverscroll-y-containを指定して止められている状態。

## 実施タスク
close #97 