### PR TITLE
feat:パスワードリセット機能実装(開発環境)

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -105,7 +105,7 @@
 
 
             <div class="mt-6 text-center"> <%# パスワードをお忘れですか？ %>
-              <%= link_to "パスワードをお忘れですか?", "#", class: "text-xs text-gray-400 text-center text-orange-400 hover:text-orange-600 border-b border-orange-400" %>
+              <%= link_to "パスワードをお忘れですか?", new_user_password_path, class: "text-xs text-gray-400 text-center text-orange-400 hover:text-orange-600 border-b border-orange-400" %>
             </div>
             <div class="my-1 text-center"> <%# まだアカウントをお持ちでない方はこちら %>
               <%= link_to "まだアカウントをお持ちでない方はこちら", new_user_registration_path, class: "text-xs text-gray-400 text-center text-orange-400 hover:text-orange-600 border-b border-orange-400" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,16 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "localhost",
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: "plain",
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,17 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = { host: "https://coloratio.fly.dev/" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              "smtp.gmail.com",
+    port:                 587,
+    domain:               "coloratio.fly.dev", # 自分のアプリのドメイン
+    user_name:            ENV["MAILER_SENDER"],
+    password:             ENV["MAILER_PASSWORD"],
+    authentication:       "plain",
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV["MAILER_SENDER"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## 実施内容
- deviseを使用してユーザーのパスワードを変更する機能を開発環境内で実装しました。
- 本番環境でのパスワード変更機能に関しては、独自ドメインの登録を行ってから実装する方が効率的だと考えたため、「ひとまず開発環境での実装する」という単位でサブissueを作成しております。

編集・作成した主なファイルは以下の通りです。
- `config/environments/development.rb`
    - 開発環境、本番環境それぞれSMTPの設定を記載。
- `config/initializers/devise.rb`
    - deviseの設定ファイル。メール送信者に関する設定を記載。

## 備考
- 「パスワードをお忘れの方ボタン」→ 送信されたメール内に記載のURLから、パスワード変更画面への遷移 → 変更したパスワードが実際に反映される、といったパスワード変更機能における一連の流れを実際に確認済み。
- viewファイルはdeviseのデフォルトコードから変更していない状態。デザイン関連のタスク時にこちらにも変更を加える予定。

## 実施タスク
close #146 