### PR TITLE
feat:保存済みパレットの編集機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,8 @@
 class PostsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    redirect_to :root, alert: "無効なURLです"
+  end
+
   def index
     unless user_signed_in?
       redirect_to top_index_path
@@ -52,32 +56,41 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     # 最新のカラー情報を取得して編集画面に渡したい。
     @palette_colors = @post.colors
+    if @post.user == current_user && @post.status == "draft"
+      render :edit
+    else
+      redirect_to posts_path, alert: "編集権限のないパレットです。"
+    end
   end
 
   def update
     # 更新する@postを取得
     @post = Post.find(params[:id])
-    # @post.idを持つpost_colorsテーブルのデータを全て削除。
-    ColorPost.where(post_id: @post.id).delete_all
-    # 新しい色を登録する
-    input_colors = color_params[:color].split(",")
-    @post.create_colors(input_colors) # create_colorsをpost.rbにメソッド記載。colorテーブルの作成と中間テーブルへの登録を行うためのメソッド。
-    # フォームの入力内容を関連するカラムにセットする。
-    @post.assign_attributes(post_params)
-    # color_countも新しい値をセットしておく。
-    @post.color_count = params[:post][:ratio].split(",").length
-    # タイトルが未記入だった場合は、デフォルトのタイトルをセットしておく。
-    @post.title = "untitled-#{@post.id}" if @post.title.blank?
-    # 全てのセットが終わってから、最後にまとめてsaveメソッド使うことでデータに反映させる。
-    if @post.save
-      if @post.status == "draft"
-        redirect_to user_path(current_user), notice: "下書き情報を更新しました。" # 作成が成功したら詳細ページへ移動する。
+    ActiveRecord::Base.transaction do
+      # @post.idを持つpost_colorsテーブルのデータを全て削除。
+      ColorPost.where(post_id: @post.id).delete_all
+      # 新しい色を登録する
+      input_colors = color_params[:color].split(",")
+      @post.create_colors(input_colors) # create_colorsをpost.rbにメソッド記載。colorテーブルの作成と中間テーブルへの登録を行うためのメソッド。
+      # フォームの入力内容を関連するカラムにセットする。
+      @post.assign_attributes(post_params)
+      # color_countも新しい値をセットしておく。
+      @post.color_count = params[:post][:ratio].split(",").length
+      # タイトルが未記入だった場合は、デフォルトのタイトルをセットしておく。
+      @post.title = "untitled-#{@post.id}" if @post.title.blank?
+      # 全てのセットが終わってから、最後にまとめてsaveメソッド使うことでデータに反映させる。
+      if @post.save
+        if @post.status == "draft"
+          redirect_to user_path(current_user), notice: "下書き情報を更新しました。" # 作成が成功したら詳細ページへ移動する。
+        else
+          redirect_to post_path(@post), notice: "パレットを公開しました。"
+        end
       else
-        redirect_to post_path(@post), notice: "パレットを公開しました。"
+        raise ActiveRecord::Rollback #saveまでうまくいかなかった時はロールバックを発生させる。
       end
-    else
-      render :edit, status: :unprocessable_entity
     end
+  rescue ActiveRecord::Rollback #ロールバックが起こった時の処理。
+    render :edit, status: :unprocessable_entity
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -56,6 +56,9 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     # 最新のカラー情報を取得して編集画面に渡したい。
     @palette_colors = @post.colors
+    # noUiSlider用のratio変数を用意する。
+    ratio = @post.ratio.split(",").map(&:to_i)
+    @slider_range = create_slider_range(ratio)
     if @post.user == current_user && @post.status == "draft"
       render :edit
     else
@@ -86,10 +89,10 @@ class PostsController < ApplicationController
           redirect_to post_path(@post), notice: "パレットを公開しました。"
         end
       else
-        raise ActiveRecord::Rollback #saveまでうまくいかなかった時はロールバックを発生させる。
+        raise ActiveRecord::Rollback # saveまでうまくいかなかった時はロールバックを発生させる。
       end
     end
-  rescue ActiveRecord::Rollback #ロールバックが起こった時の処理。
+  rescue ActiveRecord::Rollback # ロールバックが起こった時の処理。
     render :edit, status: :unprocessable_entity
   end
 
@@ -117,5 +120,16 @@ class PostsController < ApplicationController
 
   def color_params # color関連のストロングパラメータ
     params.require(:post).permit(:color)
+  end
+
+  # edit時にnoUiSlider用の比率をjsに渡すための@slider_range定義用メソッド
+  def create_slider_range(ratio)
+    slider_range = [ 0 ]
+    sum = 0
+    ratio.each do |i|
+      sum += i
+      slider_range << sum
+    end
+    slider_range
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -50,9 +50,34 @@ class PostsController < ApplicationController
 
   def edit
     @post = Post.find(params[:id])
+    # 最新のカラー情報を取得して編集画面に渡したい。
+    @palette_colors = @post.colors
   end
 
   def update
+    # 更新する@postを取得
+    @post = Post.find(params[:id])
+    # @post.idを持つpost_colorsテーブルのデータを全て削除。
+    ColorPost.where(post_id: @post.id).delete_all
+    # 新しい色を登録する
+    input_colors = color_params[:color].split(",")
+    @post.create_colors(input_colors) # create_colorsをpost.rbにメソッド記載。colorテーブルの作成と中間テーブルへの登録を行うためのメソッド。
+    # フォームの入力内容を関連するカラムにセットする。
+    @post.assign_attributes(post_params)
+    # color_countも新しい値をセットしておく。
+    @post.color_count = params[:post][:ratio].split(",").length
+    # タイトルが未記入だった場合は、デフォルトのタイトルをセットしておく。
+    @post.title = "untitled-#{@post.id}" if @post.title.blank?
+    # 全てのセットが終わってから、最後にまとめてsaveメソッド使うことでデータに反映させる。
+    if @post.save
+      if @post.status == "draft"
+        redirect_to user_path(current_user), notice: "下書き情報を更新しました。" # 作成が成功したら詳細ページへ移動する。
+      else
+        redirect_to post_path(@post), notice: "パレットを公開しました。"
+      end
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def show

--- a/app/javascript/range_slider.js
+++ b/app/javascript/range_slider.js
@@ -1,7 +1,12 @@
 document.addEventListener("turbo:load", function() {
   window.slider = document.getElementById('ratio-slider');
   // 色情報の配列を格納する変数を定義。
-  window.colors = JSON.parse(document.getElementById('tag-info').dataset.json);
+  const colorTagInfo = document.getElementById('color-tag-info');
+  window.colors = colorTagInfo ? JSON.parse(colorTagInfo.dataset.json) : null
+
+  // edit用に既存の比率を格納するためのpreEditRatio変数も定義(editページでない場合はnullで取得する。)
+  const ratioTagInfo = document.getElementById('ratio-tag-info');
+  window.preEditRatio = ratioTagInfo ? JSON.parse(ratioTagInfo.dataset.json) : null;
   // 選択中の色番号を管理するための変数を定義
   window.currentBaseNum = 0;
   // ベース追加時に登録されるデフォルトの色管理用
@@ -40,10 +45,10 @@ document.addEventListener("turbo:load", function() {
   };
 
   // スライド作成用の関数を作成しておく(グローバル)
-  window.createSlider = function(){
+  window.createSlider = function(ratio = null){
     window.colorCount = window.colors.length;
     noUiSlider.create(window.slider, {
-      start: defaultRanges[colorCount], // ハッシュのインデックスは色の数で指定することに注意(handleCountではない。)
+      start: ratio || defaultRanges[colorCount], // 引数が指定されてた場合は、その引数を元につまみの位置を設置する。ハッシュのインデックスは色の数で指定することに注意(handleCountではない。)
       behaviour: 'drag-all', //スライドをまとめてドラックできるオプション。両端をcssで動かせないようにすることで、完全に固定するための逆説的な使い方試してみた…
       connect: defaultConnects[colorCount], // 上で定義したdefaultConnectsでconnect状態を数に対応させる。
       range: {
@@ -62,8 +67,8 @@ document.addEventListener("turbo:load", function() {
     });
   }
 
-  //スライダー作成の呼び出し(ページ更新時用)
-  createSlider();
+  //スライダー作成の呼び出し(ページ更新時用。editの場合は既存の面積比率を取得する。)
+  createSlider(preEditRatio);
 
   // 色選択でベースが変更された時は、connectの色だけ変更する
   window.changeConnectColors = function(){

--- a/app/views/posts/_alpine_posts_script.html.erb
+++ b/app/views/posts/_alpine_posts_script.html.erb
@@ -1,0 +1,79 @@
+<%# パレット作成・編集ページでのAlpine実行用パーシャル %>
+<script>
+  // 下書きボタンが押された時のための処理。
+  function statusDraft(){
+    document.getElementById('post_status').value = 'draft';
+  }
+  // 公開ボタンが押された時のための処理。
+  function statusPublished(){
+    document.getElementById('post_status').value = 'published';
+  }
+
+  // 確認ダイアログを手動で出す。
+  function confirmAndSubmit(button) {
+    const message = button.dataset.turboConfirm; // turbo_confirmのメッセージを取得
+    if (confirm(message)) { // 確認ダイアログを表示
+      button.form.submit(); // フォームを送信
+    }
+  }
+
+
+  // 選択ボタンが押された時に色選択画面にベースの色を反映させるための関数。
+  // Alpine.jsで呼び出すにはhtmlのscript内で書かないといけない？？
+  function baseToSelector(basedNum){
+    window.currentBaseNum = basedNum; // 他の処理でも選択中のベース番号を扱うための上書き処理。
+    document.getElementById('selected-base').style.background = window.colors[basedNum - 1];
+    document.getElementById('selected-mini-base').style.background = window.colors[basedNum - 1];
+    document.getElementById('selected-color').textContent = window.colors[basedNum - 1];
+  }
+
+  // 削除ボタンが押された時のパレット再整列処理
+  function deleteColors(baseNum){
+    window.colors.splice(baseNum - 1, 1);
+    for (let i = 1; i <= window.colors.length; i++){
+      resetLists = document.getElementsByClassName(`reset-base-${i}`);
+      resetLists[0].style.fill = window.colors[i - 1];
+      resetLists[1].style.background = window.colors[i - 1];
+      resetLists[2].textContent = window.colors[i - 1];
+    }
+  }
+
+  // 追加ボタンが押された時のパレット再生列処理。
+  function addColors(){
+    // 候補色セットのループ処理抜け出し用変数。
+    let setSituation = false;
+    while( !setSituation ) { // setSituationがfalseの間は繰り返す。
+      // 追加候補のdefaultAddColorsから先頭の値を一つ取り出す。
+      const candidateColor = window.defaultAddColors.shift();
+      if (!window.colors.includes(candidateColor)){ // colorsにcandidateColorが含まれてない時だけ処理実行。
+        // 色を配列に一つ追加する。
+        window.colors.push(candidateColor);
+        setSituation = true;
+      }
+      // colorsに追加できたら、候補として取り出してた色をdefaultAddColorsの最後に戻す。
+      window.defaultAddColors.push(candidateColor);
+    }
+    // 配列の要素数を取得する。
+    const addIndex = window.colors.length;
+    // 配列の最後の値をベースの最後に反映させる。
+    resetLists = document.getElementsByClassName(`reset-base-${addIndex}`); //3色目が追加されたなら、それをreset-base-3に格納する。
+      resetLists[0].style.fill = window.colors[addIndex - 1];
+      resetLists[1].style.background = window.colors[addIndex - 1];
+      resetLists[2].textContent = window.colors[addIndex - 1];
+  }
+
+  // スライダーを最新に変更する関数。(色が変更される処理のときに実行する。)
+  function recreateSlider(){
+    // 現在のスライダーを削除
+    window.slider.noUiSlider.destroy();
+    // 新しいスライダーを作成
+    createSlider();
+    // つまみ間に色をつけたい。
+    connect = slider.querySelectorAll('.noUi-connect');
+    for (var i = 0; i < connect.length; i++) {
+        connect[i].style.background = window.colors[i]; // backgroundのスタイルを直接指定する。
+    }
+    window.updateRatio();
+  }
+
+</script>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,10 +1,10 @@
 <!-- source:https://codepen.io/owaiswiz/pen/jOPvEPB -->
-<% @colors = @default_palette %>
+<% @colors = @palette_colors.map(&:hex_code) %>
 <div id="tag-info" data-json=<%= @colors.to_json %>></div>
 <div x-data="{ choice: false, setting: <%= @colors.size %> }" class= "min-h-fit py-10 bg-gray-100 text-gray-900 flex items-center justify-center"> <%# フォーム画面の土台枠外span %>
   <div class="mx-20 my-5">
 
-    <div class="mb-1 text-xl font-bold">パレット作成 </div>
+    <div class="mb-1 text-xl font-bold">パレット編集 </div>
 
     <%= form_with model: @post, local: true do |f| %>
       <div class="px-2  bg-white shadow sm:rounded-lg flex flex-col lg:flex-row  items-center justify-center"> <%# フォームの大枠span・右半分と左半分で分けてるところ %>
@@ -73,7 +73,7 @@
             <%= link_to "※変更を保存せず終了する", root_path, data: { turbo_method: :get, turbo_confirm: "直近に保存した内容からの変更を反映せずに終了し、トップページに戻ります。よろしいですか?"}, class:"text-xs text-center text-blue-500 hover:text-blue-600 active:text-blue-500 underline" %>
 
             <div class="mt-5 flex gap-2 justify-end">
-              <%= f.button "下書き保存", type: 'button', onclick: "statusDraft(); confirmAndSubmit(this);", id:"draft_button", data: { turbo_confirm: 'パレットを下書き保存します'},  class:"py-2.5 px-5 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" %>
+              <%= f.button "下書きを更新", type: 'button', onclick: "statusDraft(); confirmAndSubmit(this);", id:"draft_button", data: { turbo_confirm: 'パレットを下書き保存します'},  class:"py-2.5 px-5 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" %>
               <%= f.button "公開する", type: 'button', onclick: "statusPublished(); confirmAndSubmit(this);", id:"published_button", data: { turbo_confirm: 'パレットを保存して公開します。よろしいですか？'}, class:"focus:outline-none text-white bg-orange-400 hover:bg-orange-500 font-medium rounded-lg text-sm px-5 py-2.5" %>
 
             </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,6 +1,7 @@
 <!-- source:https://codepen.io/owaiswiz/pen/jOPvEPB -->
 <% @colors = @palette_colors.map(&:hex_code) %>
-<div id="tag-info" data-json=<%= @colors.to_json %>></div>
+<div id="color-tag-info" data-json=<%= @colors.to_json %>></div>
+<div id="ratio-tag-info" data-json=<%= @slider_range.to_json %>></div>
 <div x-data="{ choice: false, setting: <%= @colors.size %> }" class= "min-h-fit py-10 bg-gray-100 text-gray-900 flex items-center justify-center"> <%# フォーム画面の土台枠外span %>
   <div class="mx-20 my-5">
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,6 @@
 <!-- source:https://codepen.io/owaiswiz/pen/jOPvEPB -->
 <% @colors = @default_palette %>
-<div id="tag-info" data-json=<%= @colors.to_json %>></div>
+<div id="color-tag-info" data-json=<%= @colors.to_json %>></div>
 <div x-data="{ choice: false, setting: <%= @colors.size %> }" class= "min-h-fit py-10 bg-gray-100 text-gray-900 flex items-center justify-center"> <%# フォーム画面の土台枠外span %>
   <div class="mx-20 my-5">
 

--- a/app/views/shared/post_card/_draft_palette.html.erb
+++ b/app/views/shared/post_card/_draft_palette.html.erb
@@ -39,7 +39,7 @@
 
   </div>
   <div class="px-6 my-3">
-    <%= link_to "#", class:"block w-full select-none rounded-lg bg-gray-900 py-3.5 px-7 text-center align-middle font-sans text-sm font-bold uppercase text-white shadow-md shadow-gray-900/10 transition-all hover:shadow-lg hover:shadow-gray-900/20 focus:opacity-[0.85] focus:shadow-none active:opacity-[0.85] active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none" do %>
+<%= link_to edit_post_path(post), class:"block w-full select-none rounded-lg bg-gray-900 py-3.5 px-7 text-center align-middle font-sans text-sm font-bold uppercase text-white shadow-md shadow-gray-900/10 transition-all hover:shadow-lg hover:shadow-gray-900/20 focus:opacity-[0.85] focus:shadow-none active:opacity-[0.85] active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none" do %>
       <div class="flex gap-1 items-center justify-center">
         <svg xmlns="http://www.w3.org/2000/svg" class="size-6" viewBox="0 0 24 24" fill="currentColor"><path d="M16.7574 2.99678L14.7574 4.99678H5V18.9968H19V9.23943L21 7.23943V19.9968C21 20.5491 20.5523 20.9968 20 20.9968H4C3.44772 20.9968 3 20.5491 3 19.9968V3.99678C3 3.4445 3.44772 2.99678 4 2.99678H16.7574ZM20.4853 2.09729L21.8995 3.5115L12.7071 12.7039L11.2954 12.7064L11.2929 11.2897L20.4853 2.09729Z"></path></svg>
         <p>編集する</p>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -2,7 +2,6 @@
   <div class="mx-10 my-14">
 
 
-
     <!-- Hero -->
     <div class="max-w-[85rem] mx-auto px-4 sm:px-6 lg:px-8">
       <!-- Grid -->

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -23,7 +23,7 @@
 
                 <div x-data="{ name: '' }" class="mt-10"> <%# ハンドルネーム入力欄 %>
                   <div class="mb-1 flex gap-1 items-center"> <%# ハンドルネームラベル用 %>
-                    <%= f.label :name, "ハンドルネーム(任意)", class:"font-bold", autocomplete:"off" %>
+                    <%= f.label :name, "ハンドルネーム(任意)", class:"font-bold" %>
 
                     <div class="relative w-fit"> <%# ハンドルネームツールチップ %>
                         <svg class="size-5 fill-gray-400 peer cursor-pointer" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM11 15V17H13V15H11ZM13 13.3551C14.4457 12.9248 15.5 11.5855 15.5 10C15.5 8.067 13.933 6.5 12 6.5C10.302 6.5 8.88637 7.70919 8.56731 9.31346L10.5288 9.70577C10.6656 9.01823 11.2723 8.5 12 8.5C12.8284 8.5 13.5 9.17157 13.5 10C13.5 10.8284 12.8284 11.5 12 11.5C11.4477 11.5 11 11.9477 11 12.5V14H13V13.3551Z"></path></svg>
@@ -39,7 +39,7 @@
 
                   </div>
 
-                  <input x-model="name" class="w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" maxlength="15" size="15" type="text" name="user[name]" id="user_name">
+                  <input x-model="name" class="w-full px-4 py-4 rounded-lg font-medium bg-gray-100 border border-gray-200 placeholder-gray-500 text-sm focus:outline-none focus:border-gray-400 focus:bg-white" maxlength="15" size="15" type="text" name="user[name]" id="user_name" autoComplete='off'>
 
                   <span class="mt-1 text-xs text-gray-500" x-text="`(${name.length}文字/15文字以内)`"></span>
                 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,4 +1,6 @@
 <!-- source:https://codepen.io/owaiswiz/pen/jOPvEPB -->
+
+
 <div class="min-h-screen bg-gray-100 text-gray-900 flex justify-center"> <%# フォーム画面の土台枠外span %>
   <div class="relative max-w-screen-xl m-20 bg-white shadow sm:rounded-lg flex justify-center flex-1"> <%# フォームの大枠span・右半分と左半分で分けてるところ %>
     <span class="absolute top-[-35px] left-0"> <%# 戻るボタン設置 %>
@@ -13,6 +15,7 @@
             <h1 class="text-2xl xl:text-3xl font-bold"> <%# 太文字「会員登録」 %>
                 会員登録
             </h1>
+
             <div class="w-full flex-1 mt-8"> <%# メアド登録＆SNSログインボタン %>
 
               <div class="mx-auto max-w-xs"> <%# メールで登録 %>


### PR DESCRIPTION
## 実施内容
- 下書き状態で保存しているパレットの編集機能を実装しました。
- 編集画面にて、既に保存しているパレット情報に基づいて、ベースやレンジスライダー、プレビューが表示されます。
- 「下書きを更新する」ボタンを押すと上書き保存され、「公開する」を押すと下書き状態から上書き状態に変更することができます。


編集・作成した主なファイルは以下の通りです。
- `app/views/posts/edit.html.erb`
    - パレット編集画面。
- `app/controllers/posts_controller.rb`
    - 編集関連のアクション、editとupdateメソッドを定義。
- `app/javascript/range_slider.js`
    - パレット編集画面が表示された際、既存パレットの情報がレンジスライダーの表示にも反映されるように微修正。

## 備考
- 下書き更新時にどこにも遷移せずに非同期でフラッシュメッセージだけ表示する形の方が良いかも。いったん下書きの上書き保存してまだ編集続けるとかはよくありそう。UIのブラッシュアップするタスクにて考える。
- パレット編集ページにて最終更新日時を表示する方が、わかりやすいかも。

## 実施タスク
close #112