### PR TITLE
feat:他ユーザーのプロフィール画面大枠作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,11 +7,16 @@ class UsersController < ApplicationController
       return
     end
 
-    published_posts = Post.where(user_id: @user.id, status: "published").order(created_at: :desc)
-    @my_page_published_posts = published_posts.limit(5)
-    @published_count = published_posts.count
-    draft_posts = Post.where(user_id: @user.id, status: "draft").order(created_at: :desc)
-    @my_page_draft_posts = draft_posts.limit(5)
-    @draft_count = draft_posts.count
+    if @user.id == current_user.id # 自分のアカウントだった場合
+      published_posts = Post.where(user_id: @user.id, status: "published").order(created_at: :desc)
+      @my_page_published_posts = published_posts.limit(5)
+      @published_count = published_posts.count
+      draft_posts = Post.where(user_id: @user.id, status: "draft").order(created_at: :desc)
+      @my_page_draft_posts = draft_posts.limit(5)
+      @draft_count = draft_posts.count
+    else # 他のユーザーだった場合
+      published_posts = Post.where(user_id: @user.id, status: "published").order(created_at: :desc)
+      @pagy, @published_posts  = pagy(published_posts)
+    end
   end
 end

--- a/app/views/users/_user_page.html.erb
+++ b/app/views/users/_user_page.html.erb
@@ -1,5 +1,59 @@
+<div class= "min-h-fit text-gray-900 flex items-center justify-center"> <%# フォーム画面の土台枠外span %>
+  <div class="m-10">
+    <div class="max-w-fit mb-10"> <%# 戻るボタン設置 %>
+      <%= render 'shared/back_button' %>
+    </div>
+    <div class="flex flex-col gap-5 mt-5 items-center"> <%# フォームの大枠span・右半分と左半分で分けてるところ %>
+      <div class="flex flex-col lg:flex-row my-20 xl:gap-10 translate md:scale-110 lg:scale-125"> <%# 上部分のプロフィールとステータス(画面サイズが小さい時だけ縦並び) %>
 
-<div>
-  <div>あなたではないユーザーのページを開いたときにこれが見えていれば正常です</div>
-  <div><%= @user.name %>さんのページを開いています。</div>
+        <div class="flex flex-col justify-center items-center p-6 pb-0"> <%# 左側欄 %>
+          <div class="w-full flex justify-center items-center"> <%# プロフィールアイコン %>
+            <svg class="size-32 md:size-56" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 256 256" xml:space="preserve">
+              <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(1.4065934065934016 1.4065934065934016) scale(2.81 2.81)">
+                <path d="M 45 0 C 20.147 0 0 20.147 0 45 c 0 24.853 20.147 45 45 45 s 45 -20.147 45 -45 C 90 20.147 69.853 0 45 0 z M 45 22.007 c 8.899 0 16.14 7.241 16.14 16.14 c 0 8.9 -7.241 16.14 -16.14 16.14 c -8.9 0 -16.14 -7.24 -16.14 -16.14 C 28.86 29.248 36.1 22.007 45 22.007 z M 45 83.843 c -11.135 0 -21.123 -4.885 -27.957 -12.623 c 3.177 -5.75 8.144 -10.476 14.05 -13.341 c 2.009 -0.974 4.354 -0.958 6.435 0.041 c 2.343 1.126 4.857 1.696 7.473 1.696 c 2.615 0 5.13 -0.571 7.473 -1.696 c 2.083 -1 4.428 -1.015 6.435 -0.041 c 5.906 2.864 10.872 7.591 14.049 13.341 C 66.123 78.957 56.135 83.843 45 83.843 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round"/>
+              </g>
+            </svg>
+          </div>
+        </div>
+
+        <div class="p-6 flex flex-col items-center lg:items-start translate md:scale-110 xl:scale-125"> <%# 名前とステータス %>
+          <div class="text-2xl font-extrabold mb-3 lg:ml-3"> <%# ユーザーネーム %>
+            <%= @user.name %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-10 my-5">
+      <% if @published_posts.present?  %> <%# 公開済みパレット用 %>
+        <div class="flex flex-col"> <%# 公開済みパレット %>
+          <div class="text-xl font-extrabold ml-3">公開パレット</div>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 place-content-center place-items-center">
+            <% @published_posts.each do |post|  %>
+              <%= render "shared/post_card/published_palette", post: post %>
+            <% end %>
+          </div>
+          <div class="text-right">
+          </div>
+        </div>
+
+      <% else %>
+        <div class="flex flex-col w-full min-h-96">
+          <div class="text-xl font-extrabold mb-3 ml-3">公開パレット</div>
+          <div class="flex-grow grid place-items-center mb-3 border-2 rounded-lg">
+            <div class="flex-col place-items-center">
+              <svg class="size-20 m-3 fill-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C17.5222 2 22 5.97778 22 10.8889C22 13.9556 19.5111 16.4444 16.4444 16.4444H14.4778C13.5556 16.4444 12.8111 17.1889 12.8111 18.1111C12.8111 18.5333 12.9778 18.9222 13.2333 19.2111C13.5 19.5111 13.6667 19.9 13.6667 20.3333C13.6667 21.2556 12.9 22 12 22C6.47778 22 2 17.5222 2 12C2 6.47778 6.47778 2 12 2ZM10.8111 18.1111C10.8111 16.0843 12.451 14.4444 14.4778 14.4444H16.4444C18.4065 14.4444 20 12.851 20 10.8889C20 7.1392 16.4677 4 12 4C7.58235 4 4 7.58235 4 12C4 16.19 7.2226 19.6285 11.324 19.9718C10.9948 19.4168 10.8111 18.7761 10.8111 18.1111ZM7.5 12C6.67157 12 6 11.3284 6 10.5C6 9.67157 6.67157 9 7.5 9C8.32843 9 9 9.67157 9 10.5C9 11.3284 8.32843 12 7.5 12ZM16.5 12C15.6716 12 15 11.3284 15 10.5C15 9.67157 15.6716 9 16.5 9C17.3284 9 18 9.67157 18 10.5C18 11.3284 17.3284 12 16.5 12ZM12 9C11.1716 9 10.5 8.32843 10.5 7.5C10.5 6.67157 11.1716 6 12 6C12.8284 6 13.5 6.67157 13.5 7.5C13.5 8.32843 12.8284 9 12 9Z"></path></svg>
+              <div class="text-sm">公開中のパレットがありません</div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- ページネーションセクション -->
+    <div class="flex items-center justify-center translate scale-150">
+      <%== pagy_nav(@pagy) %>
+    </div>
+
+  </div>
 </div>


### PR DESCRIPTION
## 実施内容
- 自分でないユーザーのプロフィールページに遷移した際のviewと、投稿済みパレットの表示を実装しました。
- usersコントローラーにて、自分のパラメータだった場合と、他ユーザーだった場合で分けて処理を書くことでマイページとの棲み分けを行っています。
- 他ユーザーページの投稿一覧表示には、ページネーションを使用しています。

編集・作成した主なファイルは以下の通りです。
- `app/controllers/users_controller.rb`
    - usersコントローラのshowメソッドにて、自分でないユーザーをパラメータとして渡していた際の処理を記載。pagyでのポスト情報取得済み。
- `app/views/users/_user_page.html.erb`
    - showアクションが実行された際、他ユーザーだった場合に表示するパーシャルファイル。コントローラで定義したインスタンス変数`@published_posts`と`@pagy`を反映。

## 備考
- 全てコントローラに処理を記載してしまっている状況なので、リファクタリング時にmodelへの移行やメソッドを定義して可読性を上げる必要あり。

## 実施タスク
close #121 