### PR TITLE
feat:投稿一覧の並び替え機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,12 +10,19 @@ class PostsController < ApplicationController
     end
     if params[:latest]
       @pagy, @posts = pagy(Post.published.latest)
+      @sort_status = 0 # alpineのソートに渡す用
     elsif params[:old]
       @pagy, @posts = pagy(Post.published.old)
+      @sort_status = 1
     elsif params[:updated]
       @pagy, @posts = pagy(Post.published.updated)
+      @sort_status = 2
+    elsif params[:most_liked]
+      @pagy, @posts = pagy(Post.published.most_liked)
+      @sort_status = 3
     else
       @pagy, @posts = pagy(Post.published.latest)
+      @sort_status = 1
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,8 +8,19 @@ class PostsController < ApplicationController
       redirect_to top_index_path
       return
     end
-    @pagy, @posts = pagy(Post.where(status: "published").order(created_at: :desc))
+    if params[:latest]
+      @pagy, @posts = pagy(Post.published.latest)
+    elsif params[:old]
+      @pagy, @posts = pagy(Post.published.old)
+    elsif params[:updated]
+      @pagy, @posts = pagy(Post.published.updated)
+    else
+      @pagy, @posts = pagy(Post.published.latest)
+    end
   end
+
+
+
 
   def new
     @default_palette = [

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,5 +1,6 @@
 class TopController < ApplicationController
   def index
-    @posts = Post.where(status: "published").order(created_at: :desc).limit(10)
+    # published、latestともにモデルでscope定義済み
+    @posts = Post.published.latest.limit(10)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,6 +10,12 @@ class Post < ApplicationRecord
   enum status: { draft: 0, published: 1 }
   validates :title, length: { maximum: 16 }
 
+  scope :published, -> {where(status: "published")} # 投稿済みのみを絞り込む用。
+  scope :latest, -> {order(created_at: :desc)} # 公開が新しい順
+  scope :old, -> {order(created_at: :asc)} # 公開が古い順
+  scope :updated, -> {order(updated_at: :desc)} # 更新が新しい順
+
+
   def create_colors(input_colors)
     input_colors.each do |color|
       # colorという名称のデータがすでにcolorカラムにある場合はそのまま、new_color変数に、もしまだ存在してなかった場合は、colorsテーブルに新しく作成した上でnew_color変数に格納する。

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,11 +10,11 @@ class Post < ApplicationRecord
   enum status: { draft: 0, published: 1 }
   validates :title, length: { maximum: 16 }
 
-  scope :published, -> {where(status: "published")} # 投稿済みのみを絞り込む用。
-  scope :latest, -> {order(created_at: :desc)} # 公開が新しい順
-  scope :old, -> {order(created_at: :asc)} # 公開が古い順
-  scope :updated, -> {order(updated_at: :desc)} # 更新が新しい順
-
+  scope :published, -> { where(status: "published") } # 投稿済みのみを絞り込む用。
+  scope :latest, -> { order(created_at: :desc) } # 公開が新しい順
+  scope :old, -> { order(created_at: :asc) } # 公開が古い順
+  scope :updated, -> { order(updated_at: :desc) } # 更新が新しい順
+  scope :most_liked, -> { left_joins(:likes).group("posts.id").order("COUNT(likes.id) DESC") }
 
   def create_colors(input_colors)
     input_colors.each do |color|

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,13 @@
 <div class= "min-h-fit text-gray-900 flex items-center justify-center">
   <div class="m-10">
     <div class="text-2xl ml-5 font-bold">投稿一覧 </div>
+
+    <!-- 工事中！！仮置き並び替えセクション -->
+    <%= link_to "公開が新しい順/", posts_path(latest: true) %>
+    <%= link_to "公開が古い順/", posts_path(old: true) %>
+    <%= link_to "最終更新日順", posts_path(updated: true) %>
+    <!-- 工事中！！！ -->
+
     <div class="flex flex-col gap-10 my-5">
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 place-content-center place-items-center">
         <% @posts.each do |post|  %> <%# @postsはすでにpublishedのものだけ入ってる状態 %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,11 +2,17 @@
   <div class="m-10">
     <div class="text-2xl ml-5 font-bold">投稿一覧 </div>
 
-    <!-- 工事中！！仮置き並び替えセクション -->
-    <%= link_to "公開が新しい順/", posts_path(latest: true) %>
-    <%= link_to "公開が古い順/", posts_path(old: true) %>
-    <%= link_to "最終更新日順", posts_path(updated: true) %>
-    <!-- 工事中！！！ -->
+    <%# 並び替え部分 %>
+    <div class="my-5">
+      <%= render "shared/sort_select" %>
+    </div>
+
+
+
+
+
+
+
 
     <div class="flex flex-col gap-10 my-5">
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 place-content-center place-items-center">

--- a/app/views/shared/_sort_select.html.erb
+++ b/app/views/shared/_sort_select.html.erb
@@ -1,0 +1,167 @@
+<div x-data="{
+        selectOpen: false,
+        selectedItem: '',
+        selectableItems: [
+            {
+                title: '公開が新しい順',
+                value: 'latest',
+                url: '<%= posts_path(latest: true) %>',
+                disabled: false
+            },
+            {
+                title: '公開が古い順',
+                value: 'old',
+                url: '<%= posts_path(old: true) %>',
+                disabled: false
+            },
+            {
+                title: '最終更新日順',
+                value: 'updated',
+                url: '<%= posts_path(updated: true) %>',
+                disabled: false
+            },
+            {
+                title: 'いいね順',
+                value: 'most_liked',
+                url: '<%= posts_path(most_liked: true) %>',
+                disabled: false
+            }
+        ],
+        selectableItemActive: null,
+        selectId: $id('select'),
+        selectKeydownValue: '',
+        selectKeydownTimeout: 1000,
+        selectKeydownClearTimeout: null,
+        selectDropdownPosition: 'bottom',
+        selectableItemIsActive(item) {
+            return this.selectableItemActive && this.selectableItemActive.value==item.value;
+        },
+        selectableItemActiveNext(){
+            let index = this.selectableItems.indexOf(this.selectableItemActive);
+            if(index < this.selectableItems.length-1){
+                this.selectableItemActive = this.selectableItems[index+1];
+                this.selectScrollToActiveItem();
+            }
+        },
+        selectableItemActivePrevious(){
+            let index = this.selectableItems.indexOf(this.selectableItemActive);
+            if(index > 0){
+                this.selectableItemActive = this.selectableItems[index-1];
+                this.selectScrollToActiveItem();
+            }
+        },
+        selectScrollToActiveItem(){
+            if(this.selectableItemActive){
+                activeElement = document.getElementById(this.selectableItemActive.value + '-' + this.selectId)
+                newScrollPos = (activeElement.offsetTop + activeElement.offsetHeight) - this.$refs.selectableItemsList.offsetHeight;
+                if(newScrollPos > 0){
+                    this.$refs.selectableItemsList.scrollTop=newScrollPos;
+                } else {
+                    this.$refs.selectableItemsList.scrollTop=0;
+                }
+            }
+        },
+        selectKeydown(event){
+            if (event.keyCode >= 65 && event.keyCode <= 90) {
+
+                this.selectKeydownValue += event.key;
+                selectedItemBestMatch = this.selectItemsFindBestMatch();
+                if(selectedItemBestMatch){
+                    if(this.selectOpen){
+                        this.selectableItemActive = selectedItemBestMatch;
+                        this.selectScrollToActiveItem();
+                    } else {
+                        this.selectedItem = this.selectableItemActive = selectedItemBestMatch;
+                    }
+                }
+
+                if(this.selectKeydownValue != ''){
+                    clearTimeout(this.selectKeydownClearTimeout);
+                    this.selectKeydownClearTimeout = setTimeout(() => {
+                        this.selectKeydownValue = '';
+                    }, this.selectKeydownTimeout);
+                }
+            }
+        },
+        selectItemsFindBestMatch(){
+            typedValue = this.selectKeydownValue.toLowerCase();
+            var bestMatch = null;
+            var bestMatchIndex = -1;
+            for (var i = 0; i < this.selectableItems.length; i++) {
+                var title = this.selectableItems[i].title.toLowerCase();
+                var index = title.indexOf(typedValue);
+                if (index > -1 && (bestMatchIndex == -1 || index < bestMatchIndex) && !this.selectableItems[i].disabled) {
+                    bestMatch = this.selectableItems[i];
+                    bestMatchIndex = index;
+                }
+            }
+            return bestMatch;
+        },
+        selectPositionUpdate(){
+            selectDropdownBottomPos = this.$refs.selectButton.getBoundingClientRect().top + this.$refs.selectButton.offsetHeight + parseInt(window.getComputedStyle(this.$refs.selectableItemsList).maxHeight);
+            if(window.innerHeight < selectDropdownBottomPos){
+                this.selectDropdownPosition = 'top';
+            } else {
+                this.selectDropdownPosition = 'bottom';
+            }
+        }
+    }"
+    x-init="
+        selectedItem = selectableItems[<%= @sort_status %>];
+        $watch('selectOpen', function(){
+            if(!selectedItem){
+                selectableItemActive=selectableItems[0];
+            } else {
+                selectableItemActive=selectedItem;
+            }
+            setTimeout(function(){
+                selectScrollToActiveItem();
+            }, 10);
+            selectPositionUpdate();
+            window.addEventListener('resize', (event) => { selectPositionUpdate(); });
+        });
+    "
+    @keydown.escape="if(selectOpen){ selectOpen=false; }"
+    @keydown.down="if(selectOpen){ selectableItemActiveNext(); } else { selectOpen=true; } event.preventDefault();"
+    @keydown.up="if(selectOpen){ selectableItemActivePrevious(); } else { selectOpen=true; } event.preventDefault();"
+    @keydown.enter="selectedItem=selectableItemActive; selectOpen=false;"
+    @keydown="selectKeydown($event);"
+    class="relative w-64 z-50">
+
+    <%# view部分 %>
+    <button  x-ref="selectButton" @click="selectOpen=!selectOpen"
+        :class="{ 'focus:ring-2 focus:ring-offset-2 focus:ring-neutral-400' : !selectOpen }"
+        class="relative min-h-[38px] flex items-center justify-between w-full py-2 pl-3 pr-10 text-left bg-white border rounded-md shadow-sm cursor-default border-neutral-200/70 focus:outline-none  text-sm">
+        <span x-text="selectedItem ? selectedItem.title : 'Select Item'" class="truncate">Select Item</span>
+        <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="w-5 h-5 text-gray-400"><path fill-rule="evenodd" d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z" clip-rule="evenodd"></path></svg>
+        </span>
+    </button>
+
+    <ul x-show="selectOpen"
+        x-ref="selectableItemsList"
+        @click.away="selectOpen = false"
+        x-transition:enter="transition ease-out duration-50"
+        x-transition:enter-start="opacity-0 -translate-y-1"
+        x-transition:enter-end="opacity-100"
+        :class="{ 'bottom-0 mb-10' : selectDropdownPosition == 'top', 'top-0 mt-10' : selectDropdownPosition == 'bottom' }"
+        class="absolute w-full py-1 mt-1 overflow-auto text-sm bg-white rounded-md shadow-md max-h-56 ring-1 ring-black ring-opacity-5 focus:outline-none"
+        x-cloak>
+
+        <template x-for="item in selectableItems" :key="item.value">
+            <a
+                @click="selectedItem=item; selectOpen=false; $refs.selectButton.focus();"
+                :href="item.url"
+                :id="item.value + '-' + selectId"
+                :data-disabled="item.disabled"
+                :class="{ 'bg-neutral-100 text-gray-900' : selectableItemIsActive(item), '' : !selectableItemIsActive(item) }"
+                @mousemove="selectableItemActive=item"
+                class="relative flex items-center h-full py-2 pl-8 text-gray-700 cursor-default select-none data-[disabled]:opacity-50 data-[disabled]:pointer-events-none">
+                <svg x-show="selectedItem.value==item.value" class="absolute left-0 w-4 h-4 ml-2 stroke-current text-neutral-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                <span class="block font-medium truncate" x-text="item.title"></span>
+            </a>
+        </template>
+
+    </ul>
+
+</div>

--- a/app/views/shared/post_card/_published_palette.html.erb
+++ b/app/views/shared/post_card/_published_palette.html.erb
@@ -14,7 +14,7 @@
 
       <!-- いいねボタン -->
       <div class="flex flex-row items-end">
-        <% if post.liked_by?(current_user) %>
+        <% if current_user && post.liked_by?(current_user) %>
           <%= render 'posts/unlike', { post: post } %>
         <% else %>
           <%= render 'posts/like', { post: post } %>


### PR DESCRIPTION
## 実施内容
- 一覧画面にて「公開が新しい順」、「公開が古い順」、「最終更新日順」、「いいね順」の4つで並び替えができるボタンを設置しました。
- ボタンの状態管理にはAlpine.js、実際の並び替え表示の実装はコントローラで条件分岐を記載することで実装しています。

![45ahseaifa](https://github.com/user-attachments/assets/c9a4f497-da72-4198-a6a1-657386870fe1)




編集・作成した主なファイルは以下の通りです。
- `app/views/posts/index.html.erb`
    - 投稿一覧画面に並び替えボタンの設置
- `app/views/shared/_sort_select.html.erb`
    - 並び替えボタンの部分テンプレートファイル
- `app/controllers/posts_controller.rb`
    - 並び替えの値によって並び順を変更するための条件分岐を記載。

## 備考
- ユーザーページや検索語の表示でも同様の並び替えボタン、および並び替えの機能を実装する必要あり。今回実装した機能を応用する。

## 実施タスク
close #111 