### PR TITLE
feat:マイページの各パレット表示タブ実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,14 +8,32 @@ class UsersController < ApplicationController
     end
 
     if @user.id == current_user.id # 自分のアカウントだった場合
-      published_posts = Post.where(user_id: @user.id, status: "published").order(created_at: :desc)
-      @my_page_published_posts = published_posts.limit(5)
+      published_posts = Post.where(user_id: @user.id, status: "published").latest
+      draft_posts = Post.where(user_id: @user.id, status: "draft").latest
+      liked_posts = @user.liked_posts
+
+      # 各パレット数取得
       @published_count = published_posts.count
-      draft_posts = Post.where(user_id: @user.id, status: "draft").order(created_at: :desc)
-      @my_page_draft_posts = draft_posts.limit(5)
       @draft_count = draft_posts.count
+      @liked_count = liked_posts.count
+
+      # 各パレット表示用
+      if params[:published]
+        @pagy, @my_published_posts = pagy(published_posts, limit: 4)
+        @selected_tab = "published"
+      elsif params[:draft]
+        @pagy, @draft_posts = pagy(draft_posts, limit: 4)
+        @selected_tab = "draft"
+      elsif params[:liked]
+        @pagy, @liked_posts = pagy(liked_posts, limit: 4)
+        @selected_tab = "liked"
+      else
+        @pagy, @my_published_posts = pagy(published_posts, limit: 4)
+        @selected_tab = "published"
+      end
+
     else # 他のユーザーだった場合
-      published_posts = Post.where(user_id: @user.id, status: "published").order(created_at: :desc)
+      published_posts = Post.where(user_id: @user.id, status: "published").latest
       @pagy, @published_posts  = pagy(published_posts)
     end
   end

--- a/app/views/users/_my_page.html.erb
+++ b/app/views/users/_my_page.html.erb
@@ -1,8 +1,5 @@
 <div class= "min-h-fit text-gray-900 flex items-center justify-center"> <%# フォーム画面の土台枠外span %>
-  <div class="m-10">
-    <div class="max-w-fit mb-10"> <%# 戻るボタン設置 %>
-      <%= render 'shared/back_button' %>
-    </div>
+  <div class="m-10 w-full">
     <div class="mb-1 text-2xl font-bold">マイページ </div>
     <div class="flex flex-col gap-5 mt-5 items-center"> <%# フォームの大枠span・右半分と左半分で分けてるところ %>
       <div class="flex flex-col lg:flex-row my-20 xl:gap-10 translate md:scale-110 lg:scale-125"> <%# 上部分のプロフィールとステータス(画面サイズが小さい時だけ縦並び) %>
@@ -45,75 +42,17 @@
                 <svg class="fill-red-400 size-8" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.001 4.52853C14.35 2.42 17.98 2.49 20.2426 4.75736C22.5053 7.02472 22.583 10.637 20.4786 12.993L11.9999 21.485L3.52138 12.993C1.41705 10.637 1.49571 7.01901 3.75736 4.75736C6.02157 2.49315 9.64519 2.41687 12.001 4.52853Z"></path></svg>
               </div>
               <div class="text-xs">いいねした数</div>
-              <div>0</div>
+              <div><%= @liked_count %></div>
             </div> <%# いいね数 %>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="flex flex-col gap-10 my-5">
-      <% if @my_page_published_posts.present?  %> <%# 公開済みパレット用 %>
-        <div class="flex flex-col"> <%# 公開済みパレット %>
-          <div class="text-xl font-extrabold ml-3">公開済みのパレット</div>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 place-content-center place-items-center">
-            <% @my_page_published_posts.each do |post|  %>
-              <%= render "shared/post_card/my_published_palette", post: post %>
-            <% end %>
-          </div>
-          <div class="text-right">
-            <div class="text-sm font-medium text-indigo-500 hover:text-indigo-600 focus-visible:outline-none focus-visible:ring focus-visible:ring-indigo-300 transition-colors duration-150 ease-out">
-              公開パレット一覧ページへ -&gt;
-            </div>
-          </div>
-        </div>
-      <% else %>
-        <div class="flex flex-col w-full min-h-96">
-          <div class="text-xl font-extrabold mb-3 ml-3">公開済みパレット</div>
-          <div class="flex-grow grid place-items-center mb-3 border-2 rounded-lg">
-            <div class="flex-col place-items-center">
-              <svg class="size-20 m-3 fill-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C17.5222 2 22 5.97778 22 10.8889C22 13.9556 19.5111 16.4444 16.4444 16.4444H14.4778C13.5556 16.4444 12.8111 17.1889 12.8111 18.1111C12.8111 18.5333 12.9778 18.9222 13.2333 19.2111C13.5 19.5111 13.6667 19.9 13.6667 20.3333C13.6667 21.2556 12.9 22 12 22C6.47778 22 2 17.5222 2 12C2 6.47778 6.47778 2 12 2ZM10.8111 18.1111C10.8111 16.0843 12.451 14.4444 14.4778 14.4444H16.4444C18.4065 14.4444 20 12.851 20 10.8889C20 7.1392 16.4677 4 12 4C7.58235 4 4 7.58235 4 12C4 16.19 7.2226 19.6285 11.324 19.9718C10.9948 19.4168 10.8111 18.7761 10.8111 18.1111ZM7.5 12C6.67157 12 6 11.3284 6 10.5C6 9.67157 6.67157 9 7.5 9C8.32843 9 9 9.67157 9 10.5C9 11.3284 8.32843 12 7.5 12ZM16.5 12C15.6716 12 15 11.3284 15 10.5C15 9.67157 15.6716 9 16.5 9C17.3284 9 18 9.67157 18 10.5C18 11.3284 17.3284 12 16.5 12ZM12 9C11.1716 9 10.5 8.32843 10.5 7.5C10.5 6.67157 11.1716 6 12 6C12.8284 6 13.5 6.67157 13.5 7.5C13.5 8.32843 12.8284 9 12 9Z"></path></svg>
-              <div class="text-sm">公開中のパレットがありません</div>
-            </div>
-          </div>
-        </div>
-      <% end %>
-
-      <% if @my_page_draft_posts.present?  %> <%# 下書きパレット確認用 %>
-        <div class="flex flex-col">
-          <div class="text-xl font-extrabold ml-3">下書きパレット</div>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 place-content-center place-items-center">
-            <% @my_page_draft_posts.each do |post|  %>
-              <%= render "shared/post_card/draft_palette", post: post %>
-            <% end %>
-          </div>
-          <div class="text-right">
-            <div class="text-sm font-medium text-indigo-500 hover:text-indigo-600 focus-visible:outline-none focus-visible:ring focus-visible:ring-indigo-300 transition-colors duration-150 ease-out">
-              下書きパレット一覧ページへ -&gt;
-            </div>
-          </div>
-        </div>
-      <% else %>
-        <div class="flex flex-col w-full min-h-96">
-          <div class="text-xl font-extrabold mb-3 ml-3">下書きパレット</div>
-          <div class="flex-grow grid place-items-center mb-3 border-2 rounded-lg">
-            <div class="flex-col place-items-center">
-              <svg class="size-20 m-3 fill-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C17.5222 2 22 5.97778 22 10.8889C22 13.9556 19.5111 16.4444 16.4444 16.4444H14.4778C13.5556 16.4444 12.8111 17.1889 12.8111 18.1111C12.8111 18.5333 12.9778 18.9222 13.2333 19.2111C13.5 19.5111 13.6667 19.9 13.6667 20.3333C13.6667 21.2556 12.9 22 12 22C6.47778 22 2 17.5222 2 12C2 6.47778 6.47778 2 12 2ZM10.8111 18.1111C10.8111 16.0843 12.451 14.4444 14.4778 14.4444H16.4444C18.4065 14.4444 20 12.851 20 10.8889C20 7.1392 16.4677 4 12 4C7.58235 4 4 7.58235 4 12C4 16.19 7.2226 19.6285 11.324 19.9718C10.9948 19.4168 10.8111 18.7761 10.8111 18.1111ZM7.5 12C6.67157 12 6 11.3284 6 10.5C6 9.67157 6.67157 9 7.5 9C8.32843 9 9 9.67157 9 10.5C9 11.3284 8.32843 12 7.5 12ZM16.5 12C15.6716 12 15 11.3284 15 10.5C15 9.67157 15.6716 9 16.5 9C17.3284 9 18 9.67157 18 10.5C18 11.3284 17.3284 12 16.5 12ZM12 9C11.1716 9 10.5 8.32843 10.5 7.5C10.5 6.67157 11.1716 6 12 6C12.8284 6 13.5 6.67157 13.5 7.5C13.5 8.32843 12.8284 9 12 9Z"></path></svg>
-              <div class="text-sm">下書き状態のパレットがありません</div>
-            </div>
-          </div>
-        </div>
-      <% end %>
-
-      <div class="flex flex-col w-full min-h-96"><%# いいねしたパレット %>
-        <div class="text-xl font-extrabold mb-3 ml-3">いいねしたパレット</div>
-        <div class="flex-grow grid place-items-center mb-3 border-2 rounded-lg">
-          <div class="flex-col place-items-center">
-            <svg class="size-20 m-3 fill-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C17.5222 2 22 5.97778 22 10.8889C22 13.9556 19.5111 16.4444 16.4444 16.4444H14.4778C13.5556 16.4444 12.8111 17.1889 12.8111 18.1111C12.8111 18.5333 12.9778 18.9222 13.2333 19.2111C13.5 19.5111 13.6667 19.9 13.6667 20.3333C13.6667 21.2556 12.9 22 12 22C6.47778 22 2 17.5222 2 12C2 6.47778 6.47778 2 12 2ZM10.8111 18.1111C10.8111 16.0843 12.451 14.4444 14.4778 14.4444H16.4444C18.4065 14.4444 20 12.851 20 10.8889C20 7.1392 16.4677 4 12 4C7.58235 4 4 7.58235 4 12C4 16.19 7.2226 19.6285 11.324 19.9718C10.9948 19.4168 10.8111 18.7761 10.8111 18.1111ZM7.5 12C6.67157 12 6 11.3284 6 10.5C6 9.67157 6.67157 9 7.5 9C8.32843 9 9 9.67157 9 10.5C9 11.3284 8.32843 12 7.5 12ZM16.5 12C15.6716 12 15 11.3284 15 10.5C15 9.67157 15.6716 9 16.5 9C17.3284 9 18 9.67157 18 10.5C18 11.3284 17.3284 12 16.5 12ZM12 9C11.1716 9 10.5 8.32843 10.5 7.5C10.5 6.67157 11.1716 6 12 6C12.8284 6 13.5 6.67157 13.5 7.5C13.5 8.32843 12.8284 9 12 9Z"></path></svg>
-            <div class="text-sm">いいねしたパレットがありません</div>
-          </div>
-        </div>
-      </div>
+    <!-- タブセクション -->
+    <div class="mx-auto">
+      <%= render "users/shared/my_page_tab" %>
     </div>
+
   </div>
 </div>

--- a/app/views/users/shared/_draft.html.erb
+++ b/app/views/users/shared/_draft.html.erb
@@ -1,0 +1,25 @@
+<!-- マイページの下書きタブ選択時の表示用 -->
+<div class="flex flex-col gap-10 my-5">
+  <div class="flex flex-col">
+    <div class="text-xl font-extrabold ml-3">下書きパレット</div>
+    <% if @draft_posts.present?  %> <%# 下書きパレット確認用 %>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 place-content-center place-items-center">
+        <% @draft_posts.each do |post|  %>
+          <%= render "shared/post_card/draft_palette", post: post %>
+        <% end %>
+      </div>
+
+      <div class="flex items-center justify-center translate scale-150">
+        <%== pagy_nav(@pagy) %>
+      </div>
+
+    <% else %>
+      <div class="flex-grow grid place-items-center mb-3 rounded-lg">
+        <div class="flex-col place-items-center">
+          <svg class="size-20 m-3 fill-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C17.5222 2 22 5.97778 22 10.8889C22 13.9556 19.5111 16.4444 16.4444 16.4444H14.4778C13.5556 16.4444 12.8111 17.1889 12.8111 18.1111C12.8111 18.5333 12.9778 18.9222 13.2333 19.2111C13.5 19.5111 13.6667 19.9 13.6667 20.3333C13.6667 21.2556 12.9 22 12 22C6.47778 22 2 17.5222 2 12C2 6.47778 6.47778 2 12 2ZM10.8111 18.1111C10.8111 16.0843 12.451 14.4444 14.4778 14.4444H16.4444C18.4065 14.4444 20 12.851 20 10.8889C20 7.1392 16.4677 4 12 4C7.58235 4 4 7.58235 4 12C4 16.19 7.2226 19.6285 11.324 19.9718C10.9948 19.4168 10.8111 18.7761 10.8111 18.1111ZM7.5 12C6.67157 12 6 11.3284 6 10.5C6 9.67157 6.67157 9 7.5 9C8.32843 9 9 9.67157 9 10.5C9 11.3284 8.32843 12 7.5 12ZM16.5 12C15.6716 12 15 11.3284 15 10.5C15 9.67157 15.6716 9 16.5 9C17.3284 9 18 9.67157 18 10.5C18 11.3284 17.3284 12 16.5 12ZM12 9C11.1716 9 10.5 8.32843 10.5 7.5C10.5 6.67157 11.1716 6 12 6C12.8284 6 13.5 6.67157 13.5 7.5C13.5 8.32843 12.8284 9 12 9Z"></path></svg>
+          <div class="text-sm">下書きパレットがありません</div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/shared/_liked.html.erb
+++ b/app/views/users/shared/_liked.html.erb
@@ -1,0 +1,25 @@
+<!-- マイページのいいねタブ選択時表示用 -->
+<div class="flex flex-col gap-10 my-5">
+  <div class="flex flex-col">
+    <div class="text-xl font-extrabold ml-3">いいねしたパレット</div>
+    <% if @liked_posts.present?  %> <%# いいねパレット確認用 %>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 place-content-center place-items-center">
+        <% @liked_posts.each do |post|  %>
+          <%= render "shared/post_card/published_palette", post: post %>
+        <% end %>
+      </div>
+
+      <div class="flex items-center justify-center translate scale-150">
+        <%== pagy_nav(@pagy) %>
+      </div>
+
+    <% else %>
+      <div class="flex-grow grid place-items-center mb-3 rounded-lg">
+        <div class="flex-col place-items-center">
+          <svg class="size-20 m-3 fill-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C17.5222 2 22 5.97778 22 10.8889C22 13.9556 19.5111 16.4444 16.4444 16.4444H14.4778C13.5556 16.4444 12.8111 17.1889 12.8111 18.1111C12.8111 18.5333 12.9778 18.9222 13.2333 19.2111C13.5 19.5111 13.6667 19.9 13.6667 20.3333C13.6667 21.2556 12.9 22 12 22C6.47778 22 2 17.5222 2 12C2 6.47778 6.47778 2 12 2ZM10.8111 18.1111C10.8111 16.0843 12.451 14.4444 14.4778 14.4444H16.4444C18.4065 14.4444 20 12.851 20 10.8889C20 7.1392 16.4677 4 12 4C7.58235 4 4 7.58235 4 12C4 16.19 7.2226 19.6285 11.324 19.9718C10.9948 19.4168 10.8111 18.7761 10.8111 18.1111ZM7.5 12C6.67157 12 6 11.3284 6 10.5C6 9.67157 6.67157 9 7.5 9C8.32843 9 9 9.67157 9 10.5C9 11.3284 8.32843 12 7.5 12ZM16.5 12C15.6716 12 15 11.3284 15 10.5C15 9.67157 15.6716 9 16.5 9C17.3284 9 18 9.67157 18 10.5C18 11.3284 17.3284 12 16.5 12ZM12 9C11.1716 9 10.5 8.32843 10.5 7.5C10.5 6.67157 11.1716 6 12 6C12.8284 6 13.5 6.67157 13.5 7.5C13.5 8.32843 12.8284 9 12 9Z"></path></svg>
+          <div class="text-sm">いいねしたパレットがありません</div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/shared/_my_page_tab.html.erb
+++ b/app/views/users/shared/_my_page_tab.html.erb
@@ -1,0 +1,40 @@
+<div x-data="{ selectedTab: '<%= @selected_tab %>' }" class="w-full">
+	<div class="mx-auto flex justify-center gap-10 overflow-x-auto border-b border-neutral-300 dark:border-neutral-700">
+
+    <%= link_to user_path(current_user, published: true) do %>
+      <button :class="selectedTab === 'published' ? 'font-bold text-black border-b-2 border-black dark:border-white dark:text-white' : 'text-neutral-600 font-medium dark:text-neutral-300 dark:hover:border-b-neutral-300 dark:hover:text-white hover:border-b-2 hover:border-b-neutral-800 hover:text-neutral-900'" class="flex h-min items-center gap-2 px-4 py-2 text-sm" type="button">
+        <svg class="size-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM9.71002 19.6674C8.74743 17.6259 8.15732 15.3742 8.02731 13H4.06189C4.458 16.1765 6.71639 18.7747 9.71002 19.6674ZM10.0307 13C10.1811 15.4388 10.8778 17.7297 12 19.752C13.1222 17.7297 13.8189 15.4388 13.9693 13H10.0307ZM19.9381 13H15.9727C15.8427 15.3742 15.2526 17.6259 14.29 19.6674C17.2836 18.7747 19.542 16.1765 19.9381 13ZM4.06189 11H8.02731C8.15732 8.62577 8.74743 6.37407 9.71002 4.33256C6.71639 5.22533 4.458 7.8235 4.06189 11ZM10.0307 11H13.9693C13.8189 8.56122 13.1222 6.27025 12 4.24799C10.8778 6.27025 10.1811 8.56122 10.0307 11ZM14.29 4.33256C15.2526 6.37407 15.8427 8.62577 15.9727 11H19.9381C19.542 7.8235 17.2836 5.22533 14.29 4.33256Z"></path></svg>
+        公開済み
+      </button>
+    <% end %>
+
+    <%= link_to user_path(current_user, draft: true) do %>
+      <button :class="selectedTab === 'draft' ? 'font-bold text-black border-b-2 border-black dark:border-white dark:text-white' : 'text-neutral-600 font-medium dark:text-neutral-300 dark:hover:border-b-neutral-300 dark:hover:text-white hover:border-b-2 hover:border-b-neutral-800 hover:text-neutral-900'" class="flex h-min items-center gap-2 px-4 py-2 text-sm" type="button">
+        <svg class="size-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2C17.5222 2 22 5.97778 22 10.8889C22 13.9556 19.5111 16.4444 16.4444 16.4444H14.4778C13.5556 16.4444 12.8111 17.1889 12.8111 18.1111C12.8111 18.5333 12.9778 18.9222 13.2333 19.2111C13.5 19.5111 13.6667 19.9 13.6667 20.3333C13.6667 21.2556 12.9 22 12 22C6.47778 22 2 17.5222 2 12C2 6.47778 6.47778 2 12 2ZM7.5 12C8.32843 12 9 11.3284 9 10.5C9 9.67157 8.32843 9 7.5 9C6.67157 9 6 9.67157 6 10.5C6 11.3284 6.67157 12 7.5 12ZM16.5 12C17.3284 12 18 11.3284 18 10.5C18 9.67157 17.3284 9 16.5 9C15.6716 9 15 9.67157 15 10.5C15 11.3284 15.6716 12 16.5 12ZM12 9C12.8284 9 13.5 8.32843 13.5 7.5C13.5 6.67157 12.8284 6 12 6C11.1716 6 10.5 6.67157 10.5 7.5C10.5 8.32843 11.1716 9 12 9Z"></path></svg>
+        下書き
+      </button>
+    <% end %>
+
+    <%= link_to user_path(current_user, liked: true) do %>
+      <button :class="selectedTab === 'liked' ? 'font-bold text-black border-b-2 border-black dark:border-white dark:text-white' : 'text-neutral-600 font-medium dark:text-neutral-300 dark:hover:border-b-neutral-300 dark:hover:text-white hover:border-b-2 hover:border-b-neutral-800 hover:text-neutral-900'" class="flex h-min items-center gap-2 px-4 py-2 text-sm" type="button">
+        <svg class="size-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.001 4.52853C14.35 2.42 17.98 2.49 20.2426 4.75736C22.5053 7.02472 22.583 10.637 20.4786 12.993L11.9999 21.485L3.52138 12.993C1.41705 10.637 1.49571 7.01901 3.75736 4.75736C6.02157 2.49315 9.64519 2.41687 12.001 4.52853Z"></path></svg>
+        いいね
+      </button>
+    <% end %>
+
+	</div>
+	<div class="px-2 py-4 text-neutral-600 dark:text-neutral-300">
+		<div x-cloak x-show="selectedTab === 'published'">
+      <%# 公開済みパレット表示用 %>
+      <%= render "users/shared/published" %>
+    </div>
+		<div x-cloak x-show="selectedTab === 'draft'">
+      <%# 下書きパレット表示用 %>
+      <%= render "users/shared/draft" %>
+    </div>
+		<div x-cloak x-show="selectedTab === 'liked'">
+      <!-- いいねしたパレット表示用 -->
+      <%= render "users/shared/liked" %>
+    </div>
+	</div>
+</div>

--- a/app/views/users/shared/_published.html.erb
+++ b/app/views/users/shared/_published.html.erb
@@ -1,0 +1,25 @@
+<!-- マイページの公開済みタブ選択時表示用 -->
+<div class="flex flex-col gap-10 my-5">
+  <div class="flex flex-col">
+    <div class="text-xl font-extrabold ml-3">公開済みパレット</div>
+    <% if @my_published_posts.present?  %> <%# 公開済みパレット確認用 %>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 place-content-center place-items-center">
+        <% @my_published_posts.each do |post|  %>
+          <%= render "shared/post_card/my_published_palette", post: post %>
+        <% end %>
+      </div>
+
+      <div class="flex items-center justify-center translate scale-150">
+        <%== pagy_nav(@pagy) %>
+      </div>
+
+    <% else %>
+      <div class="flex-grow grid place-items-center mb-3 rounded-lg">
+        <div class="flex-col place-items-center">
+          <svg class="size-20 m-3 fill-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C17.5222 2 22 5.97778 22 10.8889C22 13.9556 19.5111 16.4444 16.4444 16.4444H14.4778C13.5556 16.4444 12.8111 17.1889 12.8111 18.1111C12.8111 18.5333 12.9778 18.9222 13.2333 19.2111C13.5 19.5111 13.6667 19.9 13.6667 20.3333C13.6667 21.2556 12.9 22 12 22C6.47778 22 2 17.5222 2 12C2 6.47778 6.47778 2 12 2ZM10.8111 18.1111C10.8111 16.0843 12.451 14.4444 14.4778 14.4444H16.4444C18.4065 14.4444 20 12.851 20 10.8889C20 7.1392 16.4677 4 12 4C7.58235 4 4 7.58235 4 12C4 16.19 7.2226 19.6285 11.324 19.9718C10.9948 19.4168 10.8111 18.7761 10.8111 18.1111ZM7.5 12C6.67157 12 6 11.3284 6 10.5C6 9.67157 6.67157 9 7.5 9C8.32843 9 9 9.67157 9 10.5C9 11.3284 8.32843 12 7.5 12ZM16.5 12C15.6716 12 15 11.3284 15 10.5C15 9.67157 15.6716 9 16.5 9C17.3284 9 18 9.67157 18 10.5C18 11.3284 17.3284 12 16.5 12ZM12 9C11.1716 9 10.5 8.32843 10.5 7.5C10.5 6.67157 11.1716 6 12 6C12.8284 6 13.5 6.67157 13.5 7.5C13.5 8.32843 12.8284 9 12 9Z"></path></svg>
+          <div class="text-sm">公開済みパレットがありません</div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -10,7 +10,7 @@
 # You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
 # Here are the few that make more sense as DEFAULTs:
-# Pagy::DEFAULT[:limit]       = 20                    # default
+Pagy::DEFAULT[:limit]       = 20                    # default
 # Pagy::DEFAULT[:size]        = 7                     # default
 # Pagy::DEFAULT[:ends]        = true                  # default
 # Pagy::DEFAULT[:page_param]  = :page                 # default


### PR DESCRIPTION
## 実施内容
- マイページにおけるパレットの表示方法を、選択タブによって切り替えることができる構造に変更しました。
- タブの種類は「公開済み」「下書き」「いいね」の3つになっており、それぞれ変更することでパレットの一覧が表示されます。


編集・作成した主なファイルは以下の通りです。
- `config/initializers/pagy.rb`
    - ページネーションの表示数等、微修正。
- `app/controllers/users_controller.rb`
    - showアクションの処理にて、各パレットのタブ切り替え時の処理を記載。
- `app/views/users/shared/_my_page_tab.html.erb`
    - マイページのタブ部分を実装。

## 備考
- gem「pagy」の1ページごとの表示数設定に関して、limitで指定することで変更できる。ほとんどの記事でitemsでの指定が記載されているが変更されているので注意。
- 現段階では同期処理での一般的な遷移となってしまってるので、turboでの非同期処理でタブが変更できるようにする。
- 一覧画面のレイアウトに関して、右に余分な空白が表示されて右スクロールできる状態になってしまっている。修正必要。

## 実施タスク
close #113  #114  #115 